### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
 # Conduit Connector Plugin SDK
 
-Readme coming soon. :construction:
+[![License](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/ConduitIO/connector-plugin-sdk/blob/main/LICENSE.md)
+[![Build](https://github.com/ConduitIO/connector-plugin-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/ConduitIO/connector-plugin-sdk/actions/workflows/build.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/conduitio/connector-plugin-sdk)](https://goreportcard.com/report/github.com/conduitio/connector-plugin-sdk)
+[![Go Reference](https://pkg.go.dev/badge/github.com/conduitio/connector-plugin-sdk.svg)](https://pkg.go.dev/github.com/conduitio/connector-plugin-sdk)
+
+This repository contains the Go software development kit for implementing a connector plugin for
+[Conduit](https://github.com/conduitio/conduit). If you want to implement a connector plugin in another language please
+have a look at the [connector plugin protocol](https://github.com/conduitio/connector-plugin).
+
+## Quickstart
+
+Create a new folder and initialize a fresh go module:
+```
+go mod init example.com/conduit-plugin-demo
+```
+
+Add the connector plugin SDK dependency:
+
+```
+go get github.com/conduitio/connector-plugin-sdk
+```
+
+You need to create two structs, one that implements `sdk.Source` and another that implements `sdk.Destination`. Apart
+from that, you need to create three constructor functions where each returns a `sdk.Source`, `sdk.Destination` and
+`sdk.Specification` respectively.
+
+The plugin also needs an entrypoint that only calls `sdk.Serve`.
+
+```go
+package main
+
+import (
+	demo "example.com/conduit-plugin-demo"
+	sdk "github.com/conduitio/connector-plugin-sdk"
+)
+
+func main() {
+	sdk.Serve(
+		demo.Specification,  // func Specification() sdk.Specification { ... }
+		demo.NewSource,      // func NewSource() sdk.Source { ... }
+		demo.NewDestination, // func NewDestination() sdk.Destination { ... }
+	)
+}
+```
+
+## Examples
+
+For examples of simple plugins you can look at existing plugins like
+[conduit-plugin-generator](https://github.com/ConduitIO/conduit-plugin-generator) or
+[conduit-plugin-file](https://github.com/ConduitIO/conduit-plugin-file).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ go build path/to/main.go
 ```
 
 You will get a compiled binary which Conduit can use as a plugin. To run your plugin as part of a Conduit pipeline you
-can create a connector and specify the path to the compiled plugin binary in the field `plugin`.
+can create a connector using the connectors API, and specify the path to the compiled plugin binary in the field `plugin`.
 
 Here is an example request to `POST /v1/connectors` (find more about the [Conduit API](https://github.com/conduitio/conduit#api)):
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ func main() {
 }
 ```
 
+Now you can build the standalone plugin:
+
+```
+go build path/to/main.go
+```
+
+You will get a compiled binary which Conduit can use as a plugin. To run your plugin as part of a Conduit pipeline you
+can create a connector and specify the path to the compiled plugin binary in the field `plugin`.
+
+Here is an example request to `/POST /v1/connectors` (find more about the [Conduit API](https://github.com/conduitio/conduit#api)):
+
+```json
+{
+  "type": "TYPE_SOURCE",
+  "plugin": "/path/to/compiled/plugin/binary",
+  "pipelineId": "...",
+  "config": {
+    "name": "my-plugin",
+    "settings": {
+      "my-key": "my-value"
+    }
+  }
+}
+```
+
 ## Examples
 
 For examples of simple plugins you can look at existing plugins like

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ go build path/to/main.go
 ```
 
 You will get a compiled binary which Conduit can use as a plugin. To run your plugin as part of a Conduit pipeline you
-can create a connector using the connectors API, and specify the path to the compiled plugin binary in the field `plugin`.
+can create a connector using the connectors API and specify the path to the compiled plugin binary in the field `plugin`.
 
 Here is an example request to `POST /v1/connectors` (find more about the [Conduit API](https://github.com/conduitio/conduit#api)):
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,18 @@ Add the connector plugin SDK dependency:
 go get github.com/conduitio/connector-plugin-sdk
 ```
 
-You need to create two structs, one that implements `sdk.Source` and another that implements `sdk.Destination`. Apart
-from that, you need to create three constructor functions where each returns a `sdk.Source`, `sdk.Destination` and
-`sdk.Specification` respectively.
+With this you can start implementing the connector plugin. To implement a source (a plugin that reads from a 3rd party
+resource and sends data to Conduit) create a struct that implements
+[`sdk.Source`](https://pkg.go.dev/github.com/conduitio/connector-plugin-sdk#Source). To implement a destination (a
+plugin that receives data from Conduit and writes it to a 3rd party resource) create a struct that implements
+[`sdk.Destination`](https://pkg.go.dev/github.com/conduitio/connector-plugin-sdk#Destination). You can implement both to
+make a plugin that can be used both as a source or a destination.
 
-The plugin also needs an entrypoint that only calls `sdk.Serve`.
+Apart from the source and/or destination you should create constructor functions that return a `sdk.Source`,
+`sdk.Destination` and `sdk.Specification` respectively.
+
+The last part is the entrypoint, it needs to call `sdk.Serve` and pass in the constructor functions mentioned before. If
+the plugin does not implement a source or destination you should pass in `nil` instead.
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Conduit Connector Plugin SDK
+# Conduit Plugin SDK
 
-[![License](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/ConduitIO/connector-plugin-sdk/blob/main/LICENSE.md)
-[![Build](https://github.com/ConduitIO/connector-plugin-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/ConduitIO/connector-plugin-sdk/actions/workflows/build.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/conduitio/connector-plugin-sdk)](https://goreportcard.com/report/github.com/conduitio/connector-plugin-sdk)
-[![Go Reference](https://pkg.go.dev/badge/github.com/conduitio/connector-plugin-sdk.svg)](https://pkg.go.dev/github.com/conduitio/connector-plugin-sdk)
+[![License](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/ConduitIO/conduit-plugin-sdk/blob/main/LICENSE.md)
+[![Build](https://github.com/ConduitIO/conduit-plugin-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/ConduitIO/conduit-plugin-sdk/actions/workflows/build.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/conduitio/conduit-plugin-sdk)](https://goreportcard.com/report/github.com/conduitio/conduit-plugin-sdk)
+[![Go Reference](https://pkg.go.dev/badge/github.com/conduitio/conduit-plugin-sdk.svg)](https://pkg.go.dev/github.com/conduitio/conduit-plugin-sdk)
 
 This repository contains the Go software development kit for implementing a connector plugin for
 [Conduit](https://github.com/conduitio/conduit). If you want to implement a connector plugin in another language please
-have a look at the [connector plugin protocol](https://github.com/conduitio/connector-plugin).
+have a look at the [plugin protocol](https://github.com/conduitio/conduit-plugin-protocol).
 
 ## Quickstart
 
@@ -16,17 +16,17 @@ Create a new folder and initialize a fresh go module:
 go mod init example.com/conduit-plugin-demo
 ```
 
-Add the connector plugin SDK dependency:
+Add the plugin SDK dependency:
 
 ```
-go get github.com/conduitio/connector-plugin-sdk
+go get github.com/conduitio/conduit-plugin-sdk
 ```
 
-With this you can start implementing the connector plugin. To implement a source (a plugin that reads from a 3rd party
+With this you can start implementing the connector. To implement a source (a plugin that reads from a 3rd party
 resource and sends data to Conduit) create a struct that implements
-[`sdk.Source`](https://pkg.go.dev/github.com/conduitio/connector-plugin-sdk#Source). To implement a destination (a
+[`sdk.Source`](https://pkg.go.dev/github.com/conduitio/conduit-plugin-sdk#Source). To implement a destination (a
 plugin that receives data from Conduit and writes it to a 3rd party resource) create a struct that implements
-[`sdk.Destination`](https://pkg.go.dev/github.com/conduitio/connector-plugin-sdk#Destination). You can implement both to
+[`sdk.Destination`](https://pkg.go.dev/github.com/conduitio/conduit-plugin-sdk#Destination). You can implement both to
 make a plugin that can be used both as a source or a destination.
 
 Apart from the source and/or destination you should create constructor functions that return a `sdk.Source`,
@@ -40,7 +40,7 @@ package main
 
 import (
 	demo "example.com/conduit-plugin-demo"
-	sdk "github.com/conduitio/connector-plugin-sdk"
+	sdk "github.com/conduitio/conduit-plugin-sdk"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -1,46 +1,46 @@
-# Conduit Plugin SDK
+# Conduit Connector SDK
 
-[![License](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/ConduitIO/conduit-plugin-sdk/blob/main/LICENSE.md)
-[![Build](https://github.com/ConduitIO/conduit-plugin-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/ConduitIO/conduit-plugin-sdk/actions/workflows/build.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/conduitio/conduit-plugin-sdk)](https://goreportcard.com/report/github.com/conduitio/conduit-plugin-sdk)
-[![Go Reference](https://pkg.go.dev/badge/github.com/conduitio/conduit-plugin-sdk.svg)](https://pkg.go.dev/github.com/conduitio/conduit-plugin-sdk)
+[![License](https://img.shields.io/badge/license-Apache%202-blue)](https://github.com/ConduitIO/conduit-connector-sdk/blob/main/LICENSE.md)
+[![Build](https://github.com/ConduitIO/conduit-connector-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/ConduitIO/conduit-connector-sdk/actions/workflows/build.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/conduitio/conduit-connector-sdk)](https://goreportcard.com/report/github.com/conduitio/conduit-connector-sdk)
+[![Go Reference](https://pkg.go.dev/badge/github.com/conduitio/conduit-connector-sdk.svg)](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk)
 
-This repository contains the Go software development kit for implementing a connector plugin for
-[Conduit](https://github.com/conduitio/conduit). If you want to implement a connector plugin in another language please
-have a look at the [plugin protocol](https://github.com/conduitio/conduit-plugin-protocol).
+This repository contains the Go software development kit for implementing a connector for
+[Conduit](https://github.com/conduitio/conduit). If you want to implement a connector in another language please
+have a look at the [connector protocol](https://github.com/conduitio/conduit-connector-protocol).
 
 ## Quickstart
 
 Create a new folder and initialize a fresh go module:
 ```
-go mod init example.com/conduit-plugin-demo
+go mod init example.com/conduit-connector-demo
 ```
 
-Add the plugin SDK dependency:
+Add the connector SDK dependency:
 
 ```
-go get github.com/conduitio/conduit-plugin-sdk
+go get github.com/conduitio/conduit-connector-sdk
 ```
 
-With this you can start implementing the connector. To implement a source (a plugin that reads from a 3rd party
+With this you can start implementing the connector. To implement a source (a connector that reads from a 3rd party
 resource and sends data to Conduit) create a struct that implements
-[`sdk.Source`](https://pkg.go.dev/github.com/conduitio/conduit-plugin-sdk#Source). To implement a destination (a
-plugin that receives data from Conduit and writes it to a 3rd party resource) create a struct that implements
-[`sdk.Destination`](https://pkg.go.dev/github.com/conduitio/conduit-plugin-sdk#Destination). You can implement both to
-make a plugin that can be used both as a source or a destination.
+[`sdk.Source`](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#Source). To implement a destination (a
+connector that receives data from Conduit and writes it to a 3rd party resource) create a struct that implements
+[`sdk.Destination`](https://pkg.go.dev/github.com/conduitio/conduit-connector-sdk#Destination). You can implement both to
+make a connector that can be used both as a source or a destination.
 
 Apart from the source and/or destination you should create constructor functions that return a `sdk.Source`,
 `sdk.Destination` and `sdk.Specification` respectively.
 
 The last part is the entrypoint, it needs to call `sdk.Serve` and pass in the constructor functions mentioned before. If
-the plugin does not implement a source or destination you should pass in `nil` instead.
+the connector does not implement a source or destination you should pass in `nil` instead.
 
 ```go
 package main
 
 import (
-	demo "example.com/conduit-plugin-demo"
-	sdk "github.com/conduitio/conduit-plugin-sdk"
+	demo "example.com/conduit-connector-demo"
+	sdk "github.com/conduitio/conduit-connector-sdk"
 )
 
 func main() {
@@ -52,24 +52,24 @@ func main() {
 }
 ```
 
-Now you can build the standalone plugin:
+Now you can build the standalone connector:
 
 ```
 go build path/to/main.go
 ```
 
-You will get a compiled binary which Conduit can use as a plugin. To run your plugin as part of a Conduit pipeline you
-can create a connector using the connectors API and specify the path to the compiled plugin binary in the field `plugin`.
+You will get a compiled binary which Conduit can use as a connector. To run your connector as part of a Conduit pipeline you
+can create it using the connectors API and specify the path to the compiled connector binary in the field `plugin`.
 
 Here is an example request to `POST /v1/connectors` (find more about the [Conduit API](https://github.com/conduitio/conduit#api)):
 
 ```json
 {
   "type": "TYPE_SOURCE",
-  "plugin": "/path/to/compiled/plugin/binary",
+  "plugin": "/path/to/compiled/connector/binary",
   "pipelineId": "...",
   "config": {
-    "name": "my-plugin",
+    "name": "my-connector",
     "settings": {
       "my-key": "my-value"
     }
@@ -79,6 +79,6 @@ Here is an example request to `POST /v1/connectors` (find more about the [Condui
 
 ## Examples
 
-For examples of simple plugins you can look at existing plugins like
-[conduit-plugin-generator](https://github.com/ConduitIO/conduit-plugin-generator) or
-[conduit-plugin-file](https://github.com/ConduitIO/conduit-plugin-file).
+For examples of simple connectors you can look at existing connectors like
+[conduit-connector-generator](https://github.com/ConduitIO/conduit-connector-generator) or
+[conduit-connector-file](https://github.com/ConduitIO/conduit-connector-file).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ go build path/to/main.go
 You will get a compiled binary which Conduit can use as a plugin. To run your plugin as part of a Conduit pipeline you
 can create a connector and specify the path to the compiled plugin binary in the field `plugin`.
 
-Here is an example request to `/POST /v1/connectors` (find more about the [Conduit API](https://github.com/conduitio/conduit#api)):
+Here is an example request to `POST /v1/connectors` (find more about the [Conduit API](https://github.com/conduitio/conduit#api)):
 
 ```json
 {

--- a/destination.go
+++ b/destination.go
@@ -35,9 +35,11 @@ import (
 // Use WriteAsync if the plugin will cache records and write them to the 3rd
 // party resource in batches, otherwise use Write.
 type Destination interface {
-	// Configure is the first function to be called in a plugin. It provides the
-	// plugin with the configuration that needs to be validated and stored. In
-	// case the configuration is not valid it should return an error.
+	// Configure is the first function to be called in a connector. It provides the
+	// connector with the configuration that needs to be validated and stored.
+	// In case the configuration is not valid it should return an error.
+	// Testing if your connector can reach the configured data source should be
+	// done in Open, not in Configure.
 	Configure(context.Context, map[string]string) error
 
 	// Open is called after Configure to signal the plugin it can prepare to

--- a/destination.go
+++ b/destination.go
@@ -72,7 +72,7 @@ type Destination interface {
 
 	// Flush signals the plugin it should flush any cached records and call all
 	// outstanding AckFunc functions. This function needs to be implemented only
-	// if the struct also implements WriteAsync. No more calls to WriteAsync
+	// if the struct implements WriteAsync. No more calls to WriteAsync
 	// will be issued after Flush is called.
 	Flush(context.Context) error
 

--- a/destination.go
+++ b/destination.go
@@ -71,8 +71,9 @@ type Destination interface {
 	Write(context.Context, Record) error
 
 	// Flush signals the plugin it should flush any cached records and call all
-	// outstanding AckFunc functions. No more calls to Write will be issued
-	// after Flush is called.
+	// outstanding AckFunc functions. This function needs to be implemented only
+	// if the struct also implements WriteAsync. No more calls to WriteAsync
+	// will be issued after Flush is called.
 	Flush(context.Context) error
 
 	// Teardown signals to the plugin that all records were written and there
@@ -83,8 +84,17 @@ type Destination interface {
 	mustEmbedUnimplementedDestination()
 }
 
+// AckFunc is a function that forwards the acknowledgment to Conduit. It returns
+// an error in case the forwarding failed, otherwise it returns nil. If nil is
+// passed to this function the record is assumed to be successfully processed,
+// otherwise the parameter should contain an error describing why a record
+// failed to be processed. If an error is returned from AckFunc it should be
+// regarded as fatal and all processing should be stopped as soon as possible.
 type AckFunc func(error) error
 
+// NewDestinationPlugin takes a Destination and wraps it into an adapter that
+// converts it into a cpluginv1.DestinationPlugin. If the parameter is nil it
+// will wrap UnimplementedDestination instead.
 func NewDestinationPlugin(impl Destination) cpluginv1.DestinationPlugin {
 	if impl == nil {
 		// prevent nil pointers
@@ -96,6 +106,7 @@ func NewDestinationPlugin(impl Destination) cpluginv1.DestinationPlugin {
 type destinationPluginAdapter struct {
 	impl       Destination
 	wgAckFuncs sync.WaitGroup
+	isAsync    bool
 }
 
 func (a *destinationPluginAdapter) Configure(ctx context.Context, req cpluginv1.DestinationConfigureRequest) (cpluginv1.DestinationConfigureResponse, error) {
@@ -123,6 +134,7 @@ func (a *destinationPluginAdapter) Run(ctx context.Context, stream cpluginv1.Des
 		}
 		// WriteAsync is implemented, overwrite writeFunc as we don't need the
 		// fallback logic anymore
+		a.isAsync = true
 		writeFunc = a.writeAsync
 		return err
 	}
@@ -214,7 +226,10 @@ func (a *destinationPluginAdapter) waitForAcks(ctx context.Context) error {
 func (a *destinationPluginAdapter) Stop(ctx context.Context, req cpluginv1.DestinationStopRequest) (cpluginv1.DestinationStopResponse, error) {
 	// flush cached records
 	err := a.impl.Flush(ctx)
-	if err != nil {
+	if err != nil &&
+		// only propagate error if we are sure the plugin is writing records
+		// asynchronously or if it's some other error than ErrUnimplemented
+		(a.isAsync || !errors.Is(err, ErrUnimplemented)) {
 		return cpluginv1.DestinationStopResponse{}, err
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -21,6 +21,9 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// Logger returns an instance of a logger that can be used for leveled and
+// structured logging in a plugin. The logger will respect the log level
+// configured in Conduit.
 func Logger(ctx context.Context) *zerolog.Logger {
 	return zerolog.Ctx(ctx)
 }

--- a/record.go
+++ b/record.go
@@ -40,23 +40,36 @@ type Record struct {
 	Payload Data
 }
 
+// Position is a unique identifier for a record. It is the responsibility of the
+// Source to choose and assign record positions, it can freely choose a format
+// that makes sense and contains everything needed to restart a pipeline at a
+// certain position.
 type Position []byte
 
+// Data is a structure that contains some bytes. The only structs implementing
+// Data are RawData and StructuredData.
 type Data interface {
 	isData()
 	Bytes() []byte
 }
 
+// RawData contains unstructured data in form of a byte slice.
 type RawData []byte
 
 func (RawData) isData() {}
+
+// Bytes simply casts RawData to a byte slice.
 func (d RawData) Bytes() []byte {
 	return d
 }
 
+// StructuredData contains data in form of a map with string keys and arbitrary
+// values.
 type StructuredData map[string]interface{}
 
 func (StructuredData) isData() {}
+
+// Bytes returns the JSON encoding of the map.
 func (d StructuredData) Bytes() []byte {
 	b, err := json.Marshal(d)
 	if err != nil {

--- a/serve.go
+++ b/serve.go
@@ -22,6 +22,16 @@ import (
 	"github.com/conduitio/connector-plugin/cpluginv1/server"
 )
 
+// Serve starts the plugin and takes care of its whole lifecycle by blocking
+// until the plugin can safely stop running. Any fixable errors will be output
+// to os.Stderr and the process will exit with a status code of 1. Serve will
+// panic for unexpected conditions where a user's fix is unknown.
+//
+// It is essential that nothing gets written to stdout or stderr before this
+// function is called, as the first output is used to perform the initial
+// handshake.
+//
+// Plugins should call Serve in their main() functions.
 func Serve(
 	specFactory func() Specification,
 	sourceFactory func() Source,

--- a/source.go
+++ b/source.go
@@ -30,9 +30,11 @@ import (
 // Source fetches records from 3rd party resources and sends them to Conduit.
 // All implementations must embed UnimplementedSource for forward compatibility.
 type Source interface {
-	// Configure is the first function to be called in a plugin. It provides the
-	// plugin with the configuration that needs to be validated and stored. In
-	// case the configuration is not valid it should return an error.
+	// Configure is the first function to be called in a connector. It provides the
+	// connector with the configuration that needs to be validated and stored.
+	// In case the configuration is not valid it should return an error.
+	// Testing if your connector can reach the configured data source should be
+	// done in Open, not in Configure.
 	Configure(context.Context, map[string]string) error
 
 	// Open is called after Configure to signal the plugin it can prepare to

--- a/specifier.go
+++ b/specifier.go
@@ -52,6 +52,8 @@ type Parameter struct {
 	Description string
 }
 
+// NewSpecifierPlugin takes a Specification and wraps it into an adapter that
+// converts it into a cpluginv1.SpecifierPlugin.
 func NewSpecifierPlugin(specs Specification) cpluginv1.SpecifierPlugin {
 	return &specifierPluginAdapter{specs: specs}
 }

--- a/specifier.go
+++ b/specifier.go
@@ -36,8 +36,8 @@ type Specification struct {
 	Version string
 	// Author declares the entity that created or maintains this plugin.
 	Author string
-	// DestinationParams and SourceParams is a map of named Parameters that describe
-	// how to configure a the plugin's Destination or Source.
+	// DestinationParams and SourceParams is a map of named Parameters that
+	// describe how to configure the plugin's Destination or Source.
 	DestinationParams map[string]Parameter
 	SourceParams      map[string]Parameter
 }

--- a/unimplemented.go
+++ b/unimplemented.go
@@ -19,21 +19,35 @@ import "context"
 // UnimplementedDestination should be embedded to have forward compatible implementations.
 type UnimplementedDestination struct{}
 
+// Configure needs to be overridden in the actual implementation.
 func (UnimplementedDestination) Configure(context.Context, map[string]string) error {
 	return ErrUnimplemented
 }
+
+// Open needs to be overridden in the actual implementation.
 func (UnimplementedDestination) Open(context.Context) error {
 	return ErrUnimplemented
 }
+
+// Write needs to be overridden in the actual implementation, unless WriteAsync
+// is implemented.
 func (UnimplementedDestination) Write(context.Context, Record) error {
 	return ErrUnimplemented
 }
+
+// WriteAsync needs to be overridden in the actual implementation, unless Write
+// is implemented.
 func (UnimplementedDestination) WriteAsync(context.Context, Record, AckFunc) error {
 	return ErrUnimplemented
 }
+
+// Flush needs to be overridden in the actual implementation if WriteAsync is
+// implemented, otherwise it is optional.
 func (UnimplementedDestination) Flush(context.Context) error {
 	return ErrUnimplemented
 }
+
+// Teardown needs to be overridden in the actual implementation.
 func (UnimplementedDestination) Teardown(context.Context) error {
 	return ErrUnimplemented
 }
@@ -42,18 +56,28 @@ func (UnimplementedDestination) mustEmbedUnimplementedDestination() {}
 // UnimplementedSource should be embedded to have forward compatible implementations.
 type UnimplementedSource struct{}
 
+// Configure needs to be overridden in the actual implementation.
 func (UnimplementedSource) Configure(context.Context, map[string]string) error {
 	return ErrUnimplemented
 }
+
+// Open needs to be overridden in the actual implementation.
 func (UnimplementedSource) Open(context.Context, Position) error {
 	return ErrUnimplemented
 }
+
+// Read needs to be overridden in the actual implementation.
 func (UnimplementedSource) Read(context.Context) (Record, error) {
 	return Record{}, ErrUnimplemented
 }
+
+// Ack should be overridden if acks need to be forwarded to the source,
+// otherwise it is optional.
 func (UnimplementedSource) Ack(context.Context, Position) error {
 	return ErrUnimplemented
 }
+
+// Teardown needs to be overridden in the actual implementation.
 func (UnimplementedSource) Teardown(context.Context) error {
 	return ErrUnimplemented
 }


### PR DESCRIPTION
This adds a readme and improves the docs on public structs.

It also relaxes two requirements when implementing plugins:
- Implementing the `Source.Ack` method is not required anymore, the SDK will ignore the `ErrUnimplemented` error.
- Implementing the `Destination.Flush` method is only required if `WriteAsync` is implemented, otherwise the SDK will ignore the `ErrUnimplemented` error.