### PR TITLE
Detach context

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -1,0 +1,32 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"time"
+)
+
+// Borrowed from https://cs.opensource.google/go/x/tools/+/refs/tags/v0.1.10:internal/xcontext/xcontext.go
+
+// DetachContext returns a context that keeps all the values of its parent
+// context but detaches from the cancellation and error handling.
+func DetachContext(ctx context.Context) context.Context { return detachedContext{ctx} }
+
+type detachedContext struct{ context.Context }
+
+func (v detachedContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (v detachedContext) Done() <-chan struct{}       { return nil }
+func (v detachedContext) Err() error                  { return nil }

--- a/internal/context_test.go
+++ b/internal/context_test.go
@@ -1,0 +1,54 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func TestDetachContext(t *testing.T) {
+	is := is.New(t)
+
+	type key struct{}
+	wantValue := "foo"
+
+	assertDetachedContext := func(ctx context.Context) {
+		is.NoErr(ctx.Err())
+		is.Equal(ctx.Done(), nil)
+		deadline, ok := ctx.Deadline()
+		is.Equal(deadline, time.Time{})
+		is.True(!ok)
+		gotValue := ctx.Value(key{})
+		is.Equal(gotValue, wantValue)
+	}
+
+	// prepare context with deadline and value
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, key{}, wantValue)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second))
+	defer cancel()
+
+	// detach context and assert it is detached
+	detachedCtx := DetachContext(ctx)
+	assertDetachedContext(detachedCtx)
+
+	// cancel parent context and assert again
+	cancel()
+	assertDetachedContext(detachedCtx)
+}

--- a/source.go
+++ b/source.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
+	"github.com/conduitio/conduit-connector-sdk/internal"
 	"github.com/jpillora/backoff"
 	"gopkg.in/tomb.v2"
 )
@@ -109,8 +110,8 @@ func (a *sourcePluginAdapter) Configure(ctx context.Context, req cpluginv1.Sourc
 }
 
 func (a *sourcePluginAdapter) Start(ctx context.Context, req cpluginv1.SourceStartRequest) (cpluginv1.SourceStartResponse, error) {
-	// create a new context, so we can control when it's canceled
-	ctxOpen := context.Background()
+	// detach context, so we can control when it's canceled
+	ctxOpen := internal.DetachContext(ctx)
 	ctxOpen, a.openCancel = context.WithCancel(ctxOpen)
 
 	startDone := make(chan struct{})


### PR DESCRIPTION
This PR creates a `DetachContext` function which is taken from https://cs.opensource.google/go/x/tools/+/refs/tags/v0.1.10:internal/xcontext/xcontext.go and improved slightly. A test is added to ensure the logger is attached to the context in `Open`.

Fixes https://github.com/ConduitIO/conduit-connector-sdk/issues/5.