### PR TITLE
adds deadline to source teardown

### DIFF
--- a/source.go
+++ b/source.go
@@ -265,7 +265,8 @@ func (a *sourcePluginAdapter) Stop(ctx context.Context, req cpluginv1.SourceStop
 }
 
 func (a *sourcePluginAdapter) Teardown(ctx context.Context, req cpluginv1.SourceTeardownRequest) (cpluginv1.SourceTeardownResponse, error) {
-	// TODO add a timeout and kill plugin forcefully if needed (https://github.com/ConduitIO/conduit/issues/185)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
 	if a.t != nil {
 		_ = a.t.Wait() // wait for Run to stop running
 	}

--- a/source_test.go
+++ b/source_test.go
@@ -98,3 +98,21 @@ func TestSourcePluginAdapter_Start_Logger(t *testing.T) {
 	_, err := srcPlugin.Start(ctx, cpluginv1.SourceStartRequest{})
 	is.NoErr(err)
 }
+
+func TestSourcePluginAdapter_Teardown_Deadline(t *testing.T) {
+	is := is.New(t)
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+
+	src := NewMockSource(ctrl)
+	srcPlugin := NewSourcePlugin(src).(*sourcePluginAdapter)
+
+	src.EXPECT().Teardown(gomock.Any()).
+		Do(func(ctx context.Context) {
+			_, ok := ctx.Deadline()
+			is.True(ok)
+		})
+
+	_, err := srcPlugin.Teardown(ctx, cpluginv1.SourceTeardownRequest{})
+	is.NoErr(err)
+}


### PR DESCRIPTION
### Description

Adds a deadline to a source's Teardown to put a time limit on how long the connector will wait for Run to stop and return.

Partially addresses Conduit issue #185.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
