### PR TITLE
Acceptance tests: Generate structured data

### DIFF
--- a/acceptance_testing.go
+++ b/acceptance_testing.go
@@ -246,74 +246,27 @@ func (d ConfigurableAcceptanceTestDriver) GenerateValue(t *testing.T) interface{
 	const (
 		typeBool = iota
 		typeInt
-		typeInt8
-		typeInt16
-		typeInt32
-		typeInt64
-		typeUint
-		typeUint8
-		typeUint16
-		typeUint32
-		typeUint64
-		typeFloat32
 		typeFloat64
 		typeString
 
 		typeCount // typeCount needs to be last and contains the number of constants
 	)
 
-	// helper, we need a random bool in lots of cases
-	randBool := func() bool {
-		return rand.Int63()%2 == 0
-	}
-
 	switch rand.Int() % typeCount {
 	case typeBool:
-		return randBool()
+		return rand.Int63()%2 == 0
 	case typeInt:
 		i := rand.Int()
-		if randBool() {
+		if rand.Int63()%2 == 0 {
 			return -i - 1 // negative
 		}
 		return i
-	case typeInt8:
-		i := int8(rand.Int63() >> (64 - 8))
-		if randBool() {
-			return -i - 1 // negative
-		}
-		return i
-	case typeInt16:
-		i := int16(rand.Int63() >> (64 - 16))
-		if randBool() {
-			return -i - 1 // negative
-		}
-		return i
-	case typeInt32:
-		i := rand.Int31()
-		if randBool() {
-			return -i - 1 // negative
-		}
-		return i
-	case typeInt64:
-		i := rand.Int63()
-		if randBool() {
-			return -i - 1 // negative
-		}
-		return i
-	case typeUint:
-		return uint(rand.Int())
-	case typeUint8:
-		return uint8(rand.Int63() >> (63 - 8))
-	case typeUint16:
-		return uint16(rand.Int63() >> (63 - 16))
-	case typeUint32:
-		return rand.Uint32()
-	case typeUint64:
-		return rand.Uint64()
-	case typeFloat32:
-		return rand.Float32()
 	case typeFloat64:
-		return rand.Float64()
+		i := rand.Float64()
+		if rand.Int63()%2 == 0 {
+			return -i - 1 // negative
+		}
+		return i
 	case typeString:
 		return d.randString(rand.Intn(1024) + 32)
 	}


### PR DESCRIPTION
### Description

This PR changes how records are generated and how they are compared. By default, the driver generates records with both structured and raw data in fields `Key` and `Payload`, possibly even mixed in the same record. This behavior can be configured through `ConfigurableAcceptanceTestDriverConfig.GenerateDataType` so the caller can choose if they want the test to generate only raw or structured data. The record comparison was relaxed so that the fields `Key` and `Payload` are treated as equal if they contain different data types (e.g. raw and structured data) and both data types are converted to the same byte slice using the function `Data.Bytes()`.

Additionally, the field `CreatedAt` of the actual record is now enforced to be equal or after the `CreatedAt` value of the expected record, since the expected record is written to the 3rd party system before the actual record is retrieved.

Another assertion was added for the `Metadata` field - if the `Metadata` field does not contain any metadata it is enforced that it is actually `nil` (enforcing idiomatic Go code and reducing unnecessary allocations). If metadata is present, the comparison function will check if any metadata fields from the expected record are present and, if they are, it will enforce their content to be the same. In other words, the test doesn't force metadata to be preserved, but if it is, it should be preserved exactly as expected.

Fixes #17, fixes #18

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
