### PR TITLE
Source stop semantics

### DIFF
--- a/source.go
+++ b/source.go
@@ -95,6 +95,7 @@ type sourcePluginAdapter struct {
 	// readDone will be closed after runRead stops running.
 	readDone chan struct{}
 
+	// lastPosition stores the position of the last record sent to Conduit.
 	lastPosition Position
 
 	openCancel context.CancelFunc

--- a/source.go
+++ b/source.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync/atomic"
 	"time"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
@@ -93,14 +92,13 @@ func NewSourcePlugin(impl Source) cpluginv1.SourcePlugin {
 type sourcePluginAdapter struct {
 	impl Source
 
-	// openAcks tracks how many acks we are still waiting for.
-	openAcks int32
 	// readDone will be closed after runRead stops running.
 	readDone chan struct{}
 
+	lastPosition Position
+
 	openCancel context.CancelFunc
 	readCancel context.CancelFunc
-	ackCancel  context.CancelFunc
 	t          *tomb.Tomb
 }
 
@@ -135,11 +133,9 @@ func (a *sourcePluginAdapter) Start(ctx context.Context, req cpluginv1.SourceSta
 func (a *sourcePluginAdapter) Run(ctx context.Context, stream cpluginv1.SourceRunStream) error {
 	t, ctx := tomb.WithContext(ctx)
 	readCtx, readCancel := context.WithCancel(ctx)
-	ackCtx, ackCancel := context.WithCancel(ctx)
 
 	a.t = t
 	a.readCancel = readCancel
-	a.ackCancel = ackCancel
 	a.readDone = make(chan struct{})
 
 	t.Go(func() error {
@@ -147,7 +143,7 @@ func (a *sourcePluginAdapter) Run(ctx context.Context, stream cpluginv1.SourceRu
 		return a.runRead(readCtx, stream)
 	})
 	t.Go(func() error {
-		return a.runAck(ackCtx, stream)
+		return a.runAck(ctx, stream)
 	})
 
 	<-t.Dying() // stop as soon as it's dying
@@ -186,7 +182,7 @@ func (a *sourcePluginAdapter) runRead(ctx context.Context, stream cpluginv1.Sour
 		if err != nil {
 			return fmt.Errorf("read stream error: %w", err)
 		}
-		atomic.AddInt32(&a.openAcks, 1)
+		a.lastPosition = r.Position // store last sent position
 
 		// reset backoff retry
 		b.Reset()
@@ -194,60 +190,18 @@ func (a *sourcePluginAdapter) runRead(ctx context.Context, stream cpluginv1.Sour
 }
 
 func (a *sourcePluginAdapter) runAck(ctx context.Context, stream cpluginv1.SourceRunStream) error {
-	type streamResponse struct {
-		req cpluginv1.SourceRunRequest
-		err error
-	}
-
-	out := make(chan streamResponse)
-	// start fetching acks asynchronously and send them to the out channel
-	go func() {
-		defer close(out)
-		for {
-			req, err := stream.Recv()
-			out <- streamResponse{req, err}
-			if err != nil {
-				return // stream is closed
-			}
-		}
-	}()
-
 	for {
-		select {
-		case resp := <-out:
-			req, err := resp.req, resp.err
-			if err != nil {
-				if err == io.EOF {
-					return nil // stream is closed, not an error
-				}
-				return fmt.Errorf("ack stream error: %w", err)
+		req, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return nil // stream is closed, not an error
 			}
-			err = a.impl.Ack(ctx, req.AckPosition)
-			// implementing Ack is optional
-			if err != nil && !errors.Is(err, ErrUnimplemented) {
-				return fmt.Errorf("ack plugin error: %w", err)
-			}
-
-			// decrease number of open acks
-			atomic.AddInt32(&a.openAcks, -1)
-
-			// check if we are still producing new records
-			select {
-			case <-a.readDone:
-				// read function stopped running, check if we can stop too
-				if atomic.LoadInt32(&a.openAcks) == 0 {
-					a.ackCancel()
-				}
-			default:
-				// continue
-			}
-		case <-ctx.Done():
-			// context is cancelled when there are no more acks to be received
-
-			// once the function returns the stream will return one more EOF error,
-			// we will drain the channel to prevent a goroutine leak
-			go func() { <-out }()
-			return nil
+			return fmt.Errorf("ack stream error: %w", err)
+		}
+		err = a.impl.Ack(ctx, req.AckPosition)
+		// implementing Ack is optional
+		if err != nil && !errors.Is(err, ErrUnimplemented) {
+			return fmt.Errorf("ack plugin error: %w", err)
 		}
 	}
 }
@@ -256,21 +210,57 @@ func (a *sourcePluginAdapter) Stop(ctx context.Context, req cpluginv1.SourceStop
 	// stop reading new messages
 	a.openCancel()
 	a.readCancel()
+
+	// TODO timeout for badly written connectors
 	<-a.readDone // wait for read to actually stop running
-	if atomic.LoadInt32(&a.openAcks) == 0 {
-		// we aren't waiting for any further acks, let's stop the ack goroutine as well
-		a.ackCancel()
-	}
-	return cpluginv1.SourceStopResponse{}, nil
+
+	return cpluginv1.SourceStopResponse{
+		LastPosition: a.lastPosition,
+	}, nil
 }
 
 func (a *sourcePluginAdapter) Teardown(ctx context.Context, req cpluginv1.SourceTeardownRequest) (cpluginv1.SourceTeardownResponse, error) {
-	// TODO add a timeout and kill plugin forcefully if needed (https://github.com/ConduitIO/conduit/issues/185)
+	var waitErr error
 	if a.t != nil {
-		_ = a.t.Wait() // wait for Run to stop running
+		// wait for at most 1 minute
+		waitCtx, cancel := context.WithTimeout(ctx, time.Minute) // TODO make the timeout configurable (https://github.com/ConduitIO/conduit/issues/183)
+		defer cancel()
+
+		waitErr = a.waitForRun(waitCtx) // wait for Run to stop running
+		if waitErr != nil {
+			// just log error and continue to call Teardown to keep guarantee
+			Logger(ctx).Warn().Err(waitErr).Msg("failed to wait for Run to stop running")
+		}
 	}
+
 	err := a.impl.Teardown(ctx)
-	return cpluginv1.SourceTeardownResponse{}, err
+	if err != nil {
+		return cpluginv1.SourceTeardownResponse{}, err
+	}
+
+	return cpluginv1.SourceTeardownResponse{}, waitErr
+}
+
+// waitForRun returns once the Run function returns or the context gets
+// cancelled, whichever happens first. If the context gets cancelled the context
+// error will be returned.
+func (a *sourcePluginAdapter) waitForRun(ctx context.Context) error {
+	// wait for all acks to be sent back to Conduit
+	ackFuncsDone := make(chan struct{})
+	go func() {
+		_ = a.t.Wait() // ignore tomb error, it will be returned in Run anyway
+		close(ackFuncsDone)
+	}()
+	return a.waitForClose(ctx, ackFuncsDone)
+}
+
+func (a *sourcePluginAdapter) waitForClose(ctx context.Context, stop chan struct{}) error {
+	select {
+	case <-stop:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (a *sourcePluginAdapter) convertRecord(r Record) cpluginv1.Record {

--- a/source_test.go
+++ b/source_test.go
@@ -16,10 +16,13 @@ package sdk
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
+	cpluginv1mock "github.com/conduitio/conduit-connector-protocol/cpluginv1/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/matryer/is"
 	"github.com/rs/zerolog"
@@ -97,4 +100,187 @@ func TestSourcePluginAdapter_Start_Logger(t *testing.T) {
 
 	_, err := srcPlugin.Start(ctx, cpluginv1.SourceStartRequest{})
 	is.NoErr(err)
+}
+
+func TestSourcePluginAdapter_Run(t *testing.T) {
+	is := is.New(t)
+	ctrl := gomock.NewController(t)
+	src := NewMockSource(ctrl)
+
+	srcPlugin := NewSourcePlugin(src).(*sourcePluginAdapter)
+
+	want := Record{
+		Position:  Position("foo"),
+		Metadata:  map[string]string{"foo": "bar"},
+		CreatedAt: time.Now().UTC(),
+		Key:       RawData("bar"),
+		Payload: StructuredData{
+			"x": "y",
+			"z": 3,
+		},
+	}
+	wantLast := want
+	wantLast.Position = Position("bar")
+
+	recordCount := 5
+
+	src.EXPECT().Open(gomock.Any(), nil).Return(nil)
+
+	// first produce "normal" records, then produce last record, then return ErrBackoffRetry
+	r1 := src.EXPECT().Read(gomock.Any()).Return(want, nil).Times(recordCount - 1)
+	r2 := src.EXPECT().Read(gomock.Any()).Return(wantLast, nil).After(r1)
+	src.EXPECT().Read(gomock.Any()).Return(Record{}, ErrBackoffRetry).After(r2)
+
+	stream, reqStream, respStream := newSourceRunStreamMock(ctrl)
+
+	ctx := context.Background()
+	_, err := srcPlugin.Start(ctx, cpluginv1.SourceStartRequest{Position: nil})
+	is.NoErr(err)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		err := srcPlugin.Run(ctx, stream)
+		is.NoErr(err)
+	}()
+
+	for i := 0; i < recordCount-1; i++ {
+		resp := <-respStream
+		is.Equal(resp, cpluginv1.SourceRunResponse{
+			Record: cpluginv1.Record{
+				Position:  want.Position,
+				Metadata:  want.Metadata,
+				CreatedAt: want.CreatedAt,
+				Key:       cpluginv1.RawData(want.Key.(RawData)),
+				Payload:   cpluginv1.StructuredData(want.Payload.(StructuredData)),
+			},
+		})
+	}
+
+	// fetch last record
+	resp := <-respStream
+	is.Equal(resp, cpluginv1.SourceRunResponse{
+		Record: cpluginv1.Record{
+			Position:  wantLast.Position,
+			Metadata:  wantLast.Metadata,
+			CreatedAt: wantLast.CreatedAt,
+			Key:       cpluginv1.RawData(wantLast.Key.(RawData)),
+			Payload:   cpluginv1.StructuredData(wantLast.Payload.(StructuredData)),
+		},
+	})
+
+	stopResp, err := srcPlugin.Stop(ctx, cpluginv1.SourceStopRequest{})
+	is.NoErr(err)
+
+	is.Equal([]byte(wantLast.Position), stopResp.LastPosition) // unexpected last position
+
+	// after stop the source should stop producing new records, but it will
+	// wait for acks coming back, let's send back all acks but last one
+	src.EXPECT().Ack(gomock.Any(), want.Position).Times(recordCount - 1)
+
+	for i := 0; i < recordCount-1; i++ {
+		reqStream <- cpluginv1.SourceRunRequest{AckPosition: want.Position}
+	}
+
+	// close stream
+	close(reqStream)
+	close(respStream)
+
+	// wait for Run to exit
+	<-runDone
+}
+
+func TestSourcePluginAdapter_Teardown(t *testing.T) {
+	is := is.New(t)
+	ctrl := gomock.NewController(t)
+	src := NewMockSource(ctrl)
+
+	srcPlugin := NewSourcePlugin(src).(*sourcePluginAdapter)
+
+	src.EXPECT().Open(gomock.Any(), nil).Return(nil)
+	r1 := src.EXPECT().Read(gomock.Any()).Return(Record{}, nil)
+	src.EXPECT().Read(gomock.Any()).Return(Record{}, ErrBackoffRetry).After(r1)
+
+	stream, reqStream, respStream := newSourceRunStreamMock(ctrl)
+
+	ctx := context.Background()
+	_, err := srcPlugin.Start(ctx, cpluginv1.SourceStartRequest{Position: nil})
+	is.NoErr(err)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		err := srcPlugin.Run(ctx, stream)
+		is.NoErr(err)
+	}()
+
+	// fetch one record from stream to ensure Run started
+	<-respStream
+
+	// stop the record producing goroutine
+	_, err = srcPlugin.Stop(ctx, cpluginv1.SourceStopRequest{})
+	is.NoErr(err)
+
+	// teardown should block until the stream is closed and all acks were received
+	teardownDone := make(chan struct{})
+	go func() {
+		defer close(teardownDone)
+		_, err := srcPlugin.Teardown(ctx, cpluginv1.SourceTeardownRequest{})
+		is.NoErr(err)
+	}()
+
+	select {
+	case <-time.After(time.Millisecond * 10):
+		// all good
+	case <-teardownDone:
+		is.Fail() // teardown should block until stream is closed
+	}
+
+	// close stream and unblock teardown
+	src.EXPECT().Teardown(gomock.Any()).Return(nil)
+	close(reqStream)
+	close(respStream)
+
+	// wait for Teardown and Run to exit
+	<-teardownDone
+	<-runDone
+}
+
+func newSourceRunStreamMock(
+	ctrl *gomock.Controller,
+) (
+	*cpluginv1mock.SourceRunStream,
+	chan cpluginv1.SourceRunRequest,
+	chan cpluginv1.SourceRunResponse,
+) {
+	stream := cpluginv1mock.NewSourceRunStream(ctrl)
+
+	reqStream := make(chan cpluginv1.SourceRunRequest)
+	respStream := make(chan cpluginv1.SourceRunResponse)
+
+	stream.EXPECT().Send(gomock.Any()).
+		DoAndReturn(func(resp cpluginv1.SourceRunResponse) (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					var ok bool
+					err, ok = r.(error)
+					if !ok {
+						err = fmt.Errorf("%+v", r)
+					}
+				}
+			}()
+			respStream <- resp
+			return nil
+		}).AnyTimes()
+
+	stream.EXPECT().Recv().
+		DoAndReturn(func() (cpluginv1.SourceRunRequest, error) {
+			req, ok := <-reqStream
+			if !ok {
+				return cpluginv1.SourceRunRequest{}, io.EOF
+			}
+			return req, nil
+		}).AnyTimes()
+
+	return stream, reqStream, respStream
 }


### PR DESCRIPTION
### Description

This changes the semantics of a graceful source stop. The source now returns the information about the last record position, Conduit can now determine when it received all records and safely stop the stream. This PR also adds tests for the source `Run` function.

Second half of https://github.com/ConduitIO/conduit-connector-sdk/pull/22, fixes https://github.com/ConduitIO/conduit/issues/391 and fixes https://github.com/ConduitIO/conduit/issues/392.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
