### PR TITLE
Fix nil pointer in one-sided connectors

### DIFF
--- a/specifier.go
+++ b/specifier.go
@@ -51,6 +51,15 @@ type Parameter struct {
 // NewSpecifierPlugin takes a Specification and wraps it into an adapter that
 // converts it into a cpluginv1.SpecifierPlugin.
 func NewSpecifierPlugin(specs Specification, source Source, dest Destination) cpluginv1.SpecifierPlugin {
+	if source == nil {
+		// prevent nil pointer
+		source = UnimplementedSource{}
+	}
+	if dest == nil {
+		// prevent nil pointer
+		dest = UnimplementedDestination{}
+	}
+
 	return &specifierPluginAdapter{
 		specs:             specs,
 		sourceParams:      source.Parameters(),

--- a/specifier_test.go
+++ b/specifier_test.go
@@ -1,0 +1,39 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/conduitio/conduit-connector-protocol/cpluginv1"
+	"github.com/matryer/is"
+)
+
+func TestSpecifier_NilSource(t *testing.T) {
+	is := is.New(t)
+	// ensure that having a connector without a source still works
+	p := NewSpecifierPlugin(Specification{}, nil, UnimplementedDestination{})
+	_, err := p.Specify(context.Background(), cpluginv1.SpecifierSpecifyRequest{})
+	is.NoErr(err)
+}
+
+func TestSpecifier_NilDestination(t *testing.T) {
+	is := is.New(t)
+	// ensure that having a connector without a destination still works
+	p := NewSpecifierPlugin(Specification{}, UnimplementedSource{}, nil)
+	_, err := p.Specify(context.Background(), cpluginv1.SpecifierSpecifyRequest{})
+	is.NoErr(err)
+}


### PR DESCRIPTION
### Description

Fixes nil pointer in one-sided connectors (only a source / destination).

Fixes https://github.com/ConduitIO/conduit/issues/587.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
