### PR TITLE
fix paramgen installation command in readme

### DIFF
--- a/cmd/paramgen/README.md
+++ b/cmd/paramgen/README.md
@@ -5,7 +5,7 @@ ParamGen is a conduit tool that generates the code to return the parameters map 
 ##Installation
 Once you have installed Go, install the paramgen tool.
 ````
-go install github.com/ConduitIO/conduit-connector-sdk/cmd/paramgen@v0.4.1
+go install github.com/conduitio/conduit-connector-sdk/cmd/paramgen@latest
 ````
 
 ##Usage


### PR DESCRIPTION
### Description

paramgen readme had the wrong instructions of how to install it

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
