### PR TITLE
fix unpopulated default values bug

### DIFF
--- a/destination.go
+++ b/destination.go
@@ -89,12 +89,11 @@ type destinationPluginAdapter struct {
 func (a *destinationPluginAdapter) Configure(ctx context.Context, req cpluginv1.DestinationConfigureRequest) (cpluginv1.DestinationConfigureResponse, error) {
 	ctx = DestinationWithBatch{}.setBatchEnabled(ctx, false)
 
-	var multiErr error
 	// run builtin validations
-	multiErr = multierr.Append(multiErr, validator(a.impl.Parameters()).Validate(req.Config))
+	updatedCfg, multiErr := validator(a.impl.Parameters()).Validate(req.Config)
 	// run custom validations written by developer
-	multiErr = multierr.Append(multiErr, a.impl.Configure(ctx, req.Config))
-	multiErr = multierr.Append(multiErr, a.configureWriteStrategy(ctx, req.Config))
+	multiErr = multierr.Append(multiErr, a.impl.Configure(ctx, updatedCfg))
+	multiErr = multierr.Append(multiErr, a.configureWriteStrategy(ctx, updatedCfg))
 
 	return cpluginv1.DestinationConfigureResponse{}, multiErr
 }

--- a/destination.go
+++ b/destination.go
@@ -91,7 +91,7 @@ func (a *destinationPluginAdapter) Configure(ctx context.Context, req cpluginv1.
 
 	v := validator(a.impl.Parameters())
 	// init config and apply default values
-	updatedCfg, multiErr := v.initConfig(req.Config)
+	updatedCfg, multiErr := v.InitConfig(req.Config)
 	// run builtin validations
 	multiErr = multierr.Append(multiErr, v.Validate(updatedCfg))
 	// run custom validations written by developer

--- a/source.go
+++ b/source.go
@@ -111,7 +111,7 @@ type sourcePluginAdapter struct {
 func (a *sourcePluginAdapter) Configure(ctx context.Context, req cpluginv1.SourceConfigureRequest) (cpluginv1.SourceConfigureResponse, error) {
 	v := validator(a.impl.Parameters())
 	// init config and apply default values
-	updatedCfg, multiErr := v.initConfig(req.Config)
+	updatedCfg, multiErr := v.InitConfig(req.Config)
 	// run builtin validations
 	multiErr = multierr.Append(multiErr, validator(a.impl.Parameters()).Validate(updatedCfg))
 	// run custom validations written by developer

--- a/source.go
+++ b/source.go
@@ -109,8 +109,11 @@ type sourcePluginAdapter struct {
 }
 
 func (a *sourcePluginAdapter) Configure(ctx context.Context, req cpluginv1.SourceConfigureRequest) (cpluginv1.SourceConfigureResponse, error) {
+	v := validator(a.impl.Parameters())
+	// init config and apply default values
+	updatedCfg, multiErr := v.initConfig(req.Config)
 	// run builtin validations
-	updatedCfg, multiErr := validator(a.impl.Parameters()).Validate(req.Config)
+	multiErr = multierr.Append(multiErr, validator(a.impl.Parameters()).Validate(updatedCfg))
 	// run custom validations written by developer
 	multiErr = multierr.Append(multiErr, a.impl.Configure(ctx, updatedCfg))
 

--- a/source.go
+++ b/source.go
@@ -109,11 +109,10 @@ type sourcePluginAdapter struct {
 }
 
 func (a *sourcePluginAdapter) Configure(ctx context.Context, req cpluginv1.SourceConfigureRequest) (cpluginv1.SourceConfigureResponse, error) {
-	var multiErr error
 	// run builtin validations
-	multiErr = multierr.Append(multiErr, validator(a.impl.Parameters()).Validate(req.Config))
+	updatedCfg, multiErr := validator(a.impl.Parameters()).Validate(req.Config)
 	// run custom validations written by developer
-	multiErr = multierr.Append(multiErr, a.impl.Configure(ctx, req.Config))
+	multiErr = multierr.Append(multiErr, a.impl.Configure(ctx, updatedCfg))
 
 	return cpluginv1.SourceConfigureResponse{}, multiErr
 }

--- a/validation.go
+++ b/validation.go
@@ -194,9 +194,9 @@ func convertValidations(validations []Validation) []cpluginv1.ParameterValidatio
 // private struct to group all validation functions
 type validator map[string]Parameter
 
-// Validate is a utility function that applies all the validations for parameters, returns an error that
-// consists of a combination of errors from the configurations.
-func (v validator) Validate(config map[string]string) error {
+// Validate is a utility function that applies all the validations for parameters, returns a configuration map with assigned
+// default values, and an error that consists of a combination of errors that happened during the configuration validations.
+func (v validator) Validate(config map[string]string) (map[string]string, error) {
 	// cfg is the config map with default values assigned
 	cfg, multiErr := v.initConfig(config)
 
@@ -210,7 +210,7 @@ func (v validator) Validate(config map[string]string) error {
 		}
 		multiErr = multierr.Append(multiErr, v.validateParamValue(pKey, cfg[pKey]))
 	}
-	return multiErr
+	return cfg, multiErr
 }
 
 // validateParamValue validates that a configuration value matches all the validations required for the parameter.

--- a/validation.go
+++ b/validation.go
@@ -194,13 +194,10 @@ func convertValidations(validations []Validation) []cpluginv1.ParameterValidatio
 // private struct to group all validation functions
 type validator map[string]Parameter
 
-// Validate is a utility function that applies all the validations for parameters, returns a configuration map with assigned
-// default values, and an error that consists of a combination of errors that happened during the configuration validations.
-func (v validator) Validate(config map[string]string) (map[string]string, error) {
-	// cfg is the config map with default values assigned
-	cfg, multiErr := v.initConfig(config)
-
-	var err error
+// Validate is a utility function that applies all the validations for parameters, returns an error that consists of a
+// combination of errors that happened during the configuration validations.
+func (v validator) Validate(cfg map[string]string) error {
+	var err, multiErr error
 	for pKey := range v {
 		err = v.validateParamType(pKey, cfg[pKey])
 		if err != nil {
@@ -210,7 +207,7 @@ func (v validator) Validate(config map[string]string) (map[string]string, error)
 		}
 		multiErr = multierr.Append(multiErr, v.validateParamValue(pKey, cfg[pKey]))
 	}
-	return cfg, multiErr
+	return multiErr
 }
 
 // validateParamValue validates that a configuration value matches all the validations required for the parameter.

--- a/validation.go
+++ b/validation.go
@@ -231,9 +231,9 @@ func (v validator) validateParamValue(key string, value string) error {
 	return multiErr
 }
 
-// initConfig checks for unrecognized params, and fills any empty configuration with its assigned default value
+// InitConfig checks for unrecognized params, and fills any empty configuration with its assigned default value
 // returns an error if a parameter is not recognized.
-func (v validator) initConfig(config map[string]string) (map[string]string, error) {
+func (v validator) InitConfig(config map[string]string) (map[string]string, error) {
 	output := make(map[string]string)
 	var multiErr error
 	for key, val := range config {

--- a/validation_test.go
+++ b/validation_test.go
@@ -195,7 +195,7 @@ func TestValidation_Param_Type(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := validator(tt.params)
-			config, err := v.initConfig(tt.config)
+			config, err := v.InitConfig(tt.config)
 			is.NoErr(err)
 			err = v.Validate(config)
 			if err != nil && tt.wantErr {
@@ -397,7 +397,7 @@ func TestValidation_Param_Value(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := validator(tt.params)
-			config, err := v.initConfig(tt.config)
+			config, err := v.InitConfig(tt.config)
 			is.NoErr(err)
 			err = v.Validate(config)
 			if err != nil && tt.wantErr {
@@ -472,7 +472,7 @@ func TestValidation_Multi_Error(t *testing.T) {
 	}
 
 	v := validator(params)
-	config, err := v.initConfig(cfg)
+	config, err := v.InitConfig(cfg)
 	is.NoErr(err)
 	err = v.Validate(config)
 	is.True(err != nil)
@@ -538,7 +538,7 @@ func TestValidation_initConfig(t *testing.T) {
 	}
 
 	v := validator(params)
-	got, err := v.initConfig(config)
+	got, err := v.InitConfig(config)
 	is.NoErr(err)
 	is.Equal(got, want)
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -194,7 +194,7 @@ func TestValidation_Param_Type(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator(tt.params).Validate(tt.config)
+			_, err := validator(tt.params).Validate(tt.config)
 			if err != nil && tt.wantErr {
 				is.True(errors.Is(err, ErrInvalidParamType))
 			} else if err != nil || tt.wantErr {
@@ -393,7 +393,7 @@ func TestValidation_Param_Value(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator(tt.params).Validate(tt.config)
+			_, err := validator(tt.params).Validate(tt.config)
 			if err != nil && tt.wantErr {
 				is.True(errors.Is(err, tt.err))
 			} else if err != nil || tt.wantErr {
@@ -465,7 +465,7 @@ func TestValidation_Multi_Error(t *testing.T) {
 		"option": "five",
 	}
 
-	err := validator(params).Validate(config)
+	_, err := validator(params).Validate(config)
 	is.True(err != nil)
 
 	errs := multierr.Errors(err)
@@ -495,7 +495,7 @@ func TestValidation_Multi_Error(t *testing.T) {
 	}
 }
 
-func TestValidation_initConfig(t *testing.T) {
+func TestValidation_updatedConfig(t *testing.T) {
 	is := is.New(t)
 
 	params := map[string]Parameter{
@@ -528,7 +528,7 @@ func TestValidation_initConfig(t *testing.T) {
 		"param4": "param4",
 	}
 
-	got, err := validator(params).initConfig(config)
+	got, err := validator(params).Validate(config)
 	is.NoErr(err)
 	is.Equal(got, want)
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -194,7 +194,10 @@ func TestValidation_Param_Type(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := validator(tt.params).Validate(tt.config)
+			v := validator(tt.params)
+			config, err := v.initConfig(tt.config)
+			is.NoErr(err)
+			err = v.Validate(config)
 			if err != nil && tt.wantErr {
 				is.True(errors.Is(err, ErrInvalidParamType))
 			} else if err != nil || tt.wantErr {
@@ -393,7 +396,10 @@ func TestValidation_Param_Value(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := validator(tt.params).Validate(tt.config)
+			v := validator(tt.params)
+			config, err := v.initConfig(tt.config)
+			is.NoErr(err)
+			err = v.Validate(config)
 			if err != nil && tt.wantErr {
 				is.True(errors.Is(err, tt.err))
 			} else if err != nil || tt.wantErr {
@@ -460,12 +466,15 @@ func TestValidation_Multi_Error(t *testing.T) {
 				ValidationRequired{},
 			}},
 	}
-	config := map[string]string{
+	cfg := map[string]string{
 		"limit":  "-1",
 		"option": "five",
 	}
 
-	_, err := validator(params).Validate(config)
+	v := validator(params)
+	config, err := v.initConfig(cfg)
+	is.NoErr(err)
+	err = v.Validate(config)
 	is.True(err != nil)
 
 	errs := multierr.Errors(err)
@@ -495,7 +504,7 @@ func TestValidation_Multi_Error(t *testing.T) {
 	}
 }
 
-func TestValidation_updatedConfig(t *testing.T) {
+func TestValidation_initConfig(t *testing.T) {
 	is := is.New(t)
 
 	params := map[string]Parameter{
@@ -528,7 +537,8 @@ func TestValidation_updatedConfig(t *testing.T) {
 		"param4": "param4",
 	}
 
-	got, err := validator(params).Validate(config)
+	v := validator(params)
+	got, err := v.initConfig(config)
 	is.NoErr(err)
 	is.Equal(got, want)
 }


### PR DESCRIPTION
### Description

The fix is returning an updated map of Config that has the default values, and using that map when calling `impl.Configure()`

Fixes #50 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
