### PR TITLE
paramgen docs headers were not working

### DIFF
--- a/cmd/paramgen/README.md
+++ b/cmd/paramgen/README.md
@@ -1,14 +1,14 @@
-#ParamGen
+# ParamGen
 
 ParamGen is a conduit tool that generates the code to return the parameters map from a certain Go struct.
 
-##Installation
+## Installation
 Once you have installed Go, install the paramgen tool.
 ````
 go install github.com/conduitio/conduit-connector-sdk/cmd/paramgen@latest
 ````
 
-##Usage
+## Usage
 ParamGen has one required argument, which is the struct name, and two optional flags for the path and the output file name.
 ````
 paramgen [-path] [-output] structName
@@ -20,7 +20,7 @@ paramgen -path=./source -output=source_params SourceConfig
 This example will search for a struct called `SourceConfig` in the path `./source`, it will create a parameter map of
 only the exported fields, and generate the code to return this map in the file `source_params.go` under the same folder.
 
-###Parameter Tags 
+### Parameter Tags 
 In order to give your parameter a name, a default value, or add some validations to it, tags are the way to go.
 We have three tags that can be parsed:
 1. `json`: this tag is used to rename the parameter.
@@ -56,7 +56,7 @@ We have three tags that can be parsed:
       ```go
       Email string `validate:"regex=^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$"`
 
-##Example
+## Example
 Assume we have this configuration struct:
 ````go
 package source


### PR DESCRIPTION
### Description
docs headers don't work now https://github.com/ConduitIO/conduit-connector-sdk/tree/main/cmd/paramgen
this should fix them

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
