### PR TITLE
Acceptance test improvements

### DIFF
--- a/acceptance_testing.go
+++ b/acceptance_testing.go
@@ -511,10 +511,13 @@ func (a acceptanceTest) TestSpecifier_Specify_Success(t *testing.T) {
 	is.True(spec.Author != "")                             // Specification.Author is missing
 	is.True(strings.TrimSpace(spec.Author) == spec.Author) // Specification.Author starts or ends with whitespace
 
-	semverRegex := regexp.MustCompile(`v([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
-		`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
-		`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`)
-	is.True(semverRegex.MatchString(spec.Version)) // Specification.Version is not a valid semantic version (vX.Y.Z)
+	// allow (devel) as the version to match default behavior from runtime/debug
+	if spec.Version != "(devel)" {
+		semverRegex := regexp.MustCompile(`v([0-9]+)(\.[0-9]+)?(\.[0-9]+)?` +
+			`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+			`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?`)
+		is.True(semverRegex.MatchString(spec.Version)) // Specification.Version is not a valid semantic version "vX.Y.Z" or "(devel)"
+	}
 }
 
 func (a acceptanceTest) TestSource_Parameters_Success(t *testing.T) {


### PR DESCRIPTION
### Description

Two changes:
- Allow the version string `(devel)` in addition to semantic versions (for connectors that inject the version via `-ldflags`)
- Detect required parameters based on validation `ValidationRequired`.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests. (well these are unit tests, I ran them with the file connector)
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
