### PR TITLE
Debezium raw data

### DIFF
--- a/destination_middleware_test.go
+++ b/destination_middleware_test.go
@@ -304,8 +304,10 @@ func TestDestinationWithRecordFormat_Configure(t *testing.T) {
 			configDestinationRecordFormat: "debezium/json",
 		},
 		wantFormatter: GenericRecordFormatter{
-			Converter: DebeziumConverter{},
-			Encoder:   JSONEncoder{},
+			Converter: DebeziumConverter{
+				RawDataKey: debeziumDefaultRawDataKey,
+			},
+			Encoder: JSONEncoder{},
 		},
 	}}
 

--- a/record_formatter.go
+++ b/record_formatter.go
@@ -118,12 +118,12 @@ func (rf GenericRecordFormatter) parseFormatOptions(options string) map[string]s
 func (rf GenericRecordFormatter) Format(r Record) ([]byte, error) {
 	converted, err := rf.Converter.Convert(r)
 	if err != nil {
-		return nil, fmt.Errorf("converter fail: %w", err)
+		return nil, fmt.Errorf("converter %s failed: %w", rf.Converter.Name(), err)
 	}
 
 	out, err := rf.Encoder.Encode(converted)
 	if err != nil {
-		return nil, fmt.Errorf("encoder fail: %w", err)
+		return nil, fmt.Errorf("encoder %s failed: %w", rf.Encoder.Name(), err)
 	}
 
 	return out, nil

--- a/record_formatter_test.go
+++ b/record_formatter_test.go
@@ -53,11 +53,13 @@ func TestDebeziumConverter_Structured(t *testing.T) {
 
 	r := Record{
 		Position:  Position("foo"),
-		Operation: OperationCreate,
+		Operation: OperationUpdate,
 		Metadata:  Metadata{MetadataConduitSourcePluginName: "example"},
 		Key:       RawData("bar"),
 		Payload: Change{
-			Before: nil,
+			Before: StructuredData{
+				"bar": 123,
+			},
 			After: StructuredData{
 				"foo": "bar",
 				"baz": "qux",
@@ -73,11 +75,8 @@ func TestDebeziumConverter_Structured(t *testing.T) {
 				Type:     kafkaconnect.TypeStruct,
 				Optional: true,
 				Fields: []kafkaconnect.Schema{{
-					Field: "foo",
-					Type:  kafkaconnect.TypeString,
-				}, {
-					Field: "baz",
-					Type:  kafkaconnect.TypeString,
+					Field: "bar",
+					Type:  kafkaconnect.TypeInt64,
 				}},
 			}, {
 				Field:    "after",
@@ -122,10 +121,10 @@ func TestDebeziumConverter_Structured(t *testing.T) {
 			}},
 		},
 		Payload: kafkaconnect.DebeziumPayload{
-			Before:          nil,
+			Before:          r.Payload.Before.(StructuredData),
 			After:           r.Payload.After.(StructuredData),
 			Source:          r.Metadata,
-			Op:              kafkaconnect.DebeziumOpCreate,
+			Op:              kafkaconnect.DebeziumOpUpdate,
 			TimestampMillis: 0,
 			Transaction:     nil,
 		},

--- a/record_formatter_test.go
+++ b/record_formatter_test.go
@@ -44,10 +44,12 @@ func TestOpenCDCConverter(t *testing.T) {
 	is.Equal(got, want)
 }
 
-func TestDebeziumConverter(t *testing.T) {
+func TestDebeziumConverter_Structured(t *testing.T) {
 	is := is.New(t)
-	var converter DebeziumConverter
-	converter.SchemaName = "custom.name"
+	converter, err := DebeziumConverter{}.Configure(map[string]string{
+		"debezium.schema.name": "custom.name",
+	})
+	is.NoErr(err)
 
 	r := Record{
 		Position:  Position("foo"),
@@ -122,6 +124,95 @@ func TestDebeziumConverter(t *testing.T) {
 		Payload: kafkaconnect.DebeziumPayload{
 			Before:          nil,
 			After:           r.Payload.After.(StructuredData),
+			Source:          r.Metadata,
+			Op:              kafkaconnect.DebeziumOpCreate,
+			TimestampMillis: 0,
+			Transaction:     nil,
+		},
+	}
+
+	got, err := converter.Convert(r)
+	is.NoErr(err)
+
+	gotEnvelope, ok := got.(kafkaconnect.Envelope)
+	is.True(ok)
+	// fields in maps don't have a deterministic order, let's sort all fields
+	kafkaconnect.SortFields(&want.Schema)
+	kafkaconnect.SortFields(&gotEnvelope.Schema)
+
+	is.Equal(got, want)
+}
+
+func TestDebeziumConverter_RawData(t *testing.T) {
+	is := is.New(t)
+	converter, err := DebeziumConverter{}.Configure(map[string]string{})
+	is.NoErr(err)
+
+	r := Record{
+		Position:  Position("foo"),
+		Operation: OperationCreate,
+		Metadata:  Metadata{MetadataConduitSourcePluginName: "example"},
+		Key:       RawData("bar"),
+		Payload: Change{
+			Before: RawData("foo"),
+			After:  nil,
+		},
+	}
+	want := kafkaconnect.Envelope{
+		Schema: kafkaconnect.Schema{
+			Type: kafkaconnect.TypeStruct,
+			Fields: []kafkaconnect.Schema{{
+				Field:    "before",
+				Type:     kafkaconnect.TypeStruct,
+				Optional: true,
+				Fields: []kafkaconnect.Schema{{
+					Optional: true,
+					Field:    "opencdc.rawData",
+					Type:     kafkaconnect.TypeBytes,
+				}},
+			}, {
+				Field:    "after",
+				Type:     kafkaconnect.TypeStruct,
+				Optional: true,
+				Fields: []kafkaconnect.Schema{{
+					Optional: true,
+					Field:    "opencdc.rawData",
+					Type:     kafkaconnect.TypeBytes,
+				}},
+			}, {
+				Field:    "source",
+				Type:     kafkaconnect.TypeStruct,
+				Optional: true,
+				Fields: []kafkaconnect.Schema{{
+					Field: "conduit.source.plugin.name",
+					Type:  kafkaconnect.TypeString,
+				}},
+			}, {
+				Field: "op",
+				Type:  kafkaconnect.TypeString,
+			}, {
+				Field:    "ts_ms",
+				Type:     kafkaconnect.TypeInt64,
+				Optional: true,
+			}, {
+				Field:    "transaction",
+				Type:     kafkaconnect.TypeStruct,
+				Optional: true,
+				Fields: []kafkaconnect.Schema{{
+					Field: "id",
+					Type:  kafkaconnect.TypeString,
+				}, {
+					Field: "total_order",
+					Type:  kafkaconnect.TypeInt64,
+				}, {
+					Field: "data_collection_order",
+					Type:  kafkaconnect.TypeInt64,
+				}},
+			}},
+		},
+		Payload: kafkaconnect.DebeziumPayload{
+			Before:          StructuredData{"opencdc.rawData": []byte("foo")},
+			After:           nil,
 			Source:          r.Metadata,
 			Op:              kafkaconnect.DebeziumOpCreate,
 			TimestampMillis: 0,


### PR DESCRIPTION
### Description

This PR makes sure that records that contain actual raw data can be converted to debezium records by hoisting the raw data into a field. By default that field is named `opencdc.rawData` but it can be changed by setting `debezium.rawData.key`.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
