### PR TITLE
Paramgen: don't add prefix if nested field is not named

### DIFF
--- a/cmd/paramgen/internal/paramgen.go
+++ b/cmd/paramgen/internal/paramgen.go
@@ -430,10 +430,6 @@ func (p *parameterParser) attachPrefix(f *ast.Field, params map[string]sdk.Param
 	if prefix == "" && len(f.Names) > 0 {
 		prefix = p.formatFieldName(f.Names[0].Name)
 	}
-	// if it's a struct, then prefix is the struct name
-	if n, ok := f.Type.(*ast.Ident); ok && prefix == "" {
-		prefix = p.formatFieldName(n.Name)
-	}
 	if prefix == "" {
 		// no prefix to attach
 		return params

--- a/cmd/paramgen/internal/paramgen_test.go
+++ b/cmd/paramgen/internal/paramgen_test.go
@@ -34,7 +34,7 @@ func TestParseSpecificationSuccess(t *testing.T) {
 		name: "SourceConfig",
 		pkg:  "example",
 		want: map[string]sdk.Parameter{
-			"globalConfig.foo": {
+			"foo": {
 				Default:     "bar",
 				Description: "foo is a required field in the global config with the name \"foo\" and default value \"bar\".",
 				Type:        sdk.ParameterTypeString,
@@ -107,7 +107,7 @@ func TestParseSpecificationSuccess(t *testing.T) {
 			name: "Config",
 			pkg:  "tags",
 			want: map[string]sdk.Parameter{
-				"innerConfig.my-name": {
+				"my-name": {
 					Type:        sdk.ParameterTypeString,
 					Validations: []sdk.Validation{sdk.ValidationRequired{}},
 				},


### PR DESCRIPTION
### Description

This fixes a mismatch between `paramgen` and `sdk.Util.ParseConfig`, where `ParseConfig` did not expect that embedded structs without a name would have a prefix (see [this test case](https://github.com/ConduitIO/conduit-connector-sdk/blob/29058268e9933edc3f99fcb62f01015a4c778fbd/util_test.go#L57)). Now `paramgen` also does not add that prefix to generated parameters.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
