### PR TITLE
Lifecycle event methods

### DIFF
--- a/destination.go
+++ b/destination.go
@@ -77,7 +77,7 @@ type Destination interface {
 	// skipped if the connector configuration did not change. It can be used to
 	// update anything that was initialized in LifecycleOnCreated, in case the
 	// configuration change affects it.
-	LifecycleOnUpdated(ctx context.Context, configBefore map[string]string, configAfter map[string]string) error
+	LifecycleOnUpdated(ctx context.Context, configBefore, configAfter map[string]string) error
 	// LifecycleOnDeleted is called when the connector was deleted. It will be
 	// the only method that is called in that case. This method can be used to
 	// clean up anything that was initialized in LifecycleOnCreated.

--- a/destination_test.go
+++ b/destination_test.go
@@ -253,6 +253,58 @@ func TestDestinationPluginAdapter_Stop_AwaitLastRecord(t *testing.T) {
 	<-runDone
 }
 
+func TestDestinationPluginAdapter_LifecycleOnCreated(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	dst := NewMockDestination(ctrl)
+
+	dstPlugin := NewDestinationPlugin(dst).(*destinationPluginAdapter)
+
+	want := map[string]string{"foo": "bar"}
+	dst.EXPECT().LifecycleOnCreated(ctx, want).Return(nil)
+
+	req := cpluginv1.DestinationLifecycleOnCreatedRequest{Config: want}
+	_, err := dstPlugin.LifecycleOnCreated(ctx, req)
+	is.NoErr(err)
+}
+
+func TestDestinationPluginAdapter_LifecycleOnUpdated(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	dst := NewMockDestination(ctrl)
+
+	dstPlugin := NewDestinationPlugin(dst).(*destinationPluginAdapter)
+
+	wantBefore := map[string]string{"foo": "bar"}
+	wantAfter := map[string]string{"foo": "baz"}
+	dst.EXPECT().LifecycleOnUpdated(ctx, wantBefore, wantAfter).Return(nil)
+
+	req := cpluginv1.DestinationLifecycleOnUpdatedRequest{
+		ConfigBefore: wantBefore,
+		ConfigAfter:  wantAfter,
+	}
+	_, err := dstPlugin.LifecycleOnUpdated(ctx, req)
+	is.NoErr(err)
+}
+
+func TestDestinationPluginAdapter_LifecycleOnDeleted(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	dst := NewMockDestination(ctrl)
+
+	dstPlugin := NewDestinationPlugin(dst).(*destinationPluginAdapter)
+
+	want := map[string]string{"foo": "bar"}
+	dst.EXPECT().LifecycleOnDeleted(ctx, want).Return(nil)
+
+	req := cpluginv1.DestinationLifecycleOnDeletedRequest{Config: want}
+	_, err := dstPlugin.LifecycleOnDeleted(ctx, req)
+	is.NoErr(err)
+}
+
 func newDestinationRunStreamMock(
 	ctrl *gomock.Controller,
 ) (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/conduitio/conduit-connector-protocol v0.4.1
+	github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a
 	github.com/golang/mock v1.6.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/matryer/is v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/conduitio/conduit-connector-protocol v0.4.1 h1:QIqvkpfVVSxsBHltMKRpy4l5u1M3psAF0SePxhv+CTU=
-github.com/conduitio/conduit-connector-protocol v0.4.1/go.mod h1:UIhHWxq52hvwwbkvQDaRgZRHfbpDDmU7tZaw0mwLdd4=
+github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a h1:xGtOYeXg6+7HMGlJ+Vjp/0FnP+tnjjIe26xEdeEep+Y=
+github.com/conduitio/conduit-connector-protocol v0.4.2-0.20230317135836-683b23ba5a0a/go.mod h1:UIhHWxq52hvwwbkvQDaRgZRHfbpDDmU7tZaw0mwLdd4=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/mock_destination_test.go
+++ b/mock_destination_test.go
@@ -47,6 +47,48 @@ func (mr *MockDestinationMockRecorder) Configure(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockDestination)(nil).Configure), arg0, arg1)
 }
 
+// LifecycleOnCreated mocks base method.
+func (m *MockDestination) LifecycleOnCreated(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnCreated", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnCreated indicates an expected call of LifecycleOnCreated.
+func (mr *MockDestinationMockRecorder) LifecycleOnCreated(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnCreated", reflect.TypeOf((*MockDestination)(nil).LifecycleOnCreated), arg0, arg1)
+}
+
+// LifecycleOnDeleted mocks base method.
+func (m *MockDestination) LifecycleOnDeleted(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnDeleted", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnDeleted indicates an expected call of LifecycleOnDeleted.
+func (mr *MockDestinationMockRecorder) LifecycleOnDeleted(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnDeleted", reflect.TypeOf((*MockDestination)(nil).LifecycleOnDeleted), arg0, arg1)
+}
+
+// LifecycleOnUpdated mocks base method.
+func (m *MockDestination) LifecycleOnUpdated(arg0 context.Context, arg1, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnUpdated", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnUpdated indicates an expected call of LifecycleOnUpdated.
+func (mr *MockDestinationMockRecorder) LifecycleOnUpdated(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnUpdated", reflect.TypeOf((*MockDestination)(nil).LifecycleOnUpdated), arg0, arg1, arg2)
+}
+
 // Open mocks base method.
 func (m *MockDestination) Open(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/mock_source_test.go
+++ b/mock_source_test.go
@@ -61,6 +61,48 @@ func (mr *MockSourceMockRecorder) Configure(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockSource)(nil).Configure), arg0, arg1)
 }
 
+// LifecycleOnCreated mocks base method.
+func (m *MockSource) LifecycleOnCreated(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnCreated", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnCreated indicates an expected call of LifecycleOnCreated.
+func (mr *MockSourceMockRecorder) LifecycleOnCreated(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnCreated", reflect.TypeOf((*MockSource)(nil).LifecycleOnCreated), arg0, arg1)
+}
+
+// LifecycleOnDeleted mocks base method.
+func (m *MockSource) LifecycleOnDeleted(arg0 context.Context, arg1 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnDeleted", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnDeleted indicates an expected call of LifecycleOnDeleted.
+func (mr *MockSourceMockRecorder) LifecycleOnDeleted(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnDeleted", reflect.TypeOf((*MockSource)(nil).LifecycleOnDeleted), arg0, arg1)
+}
+
+// LifecycleOnUpdated mocks base method.
+func (m *MockSource) LifecycleOnUpdated(arg0 context.Context, arg1, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LifecycleOnUpdated", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LifecycleOnUpdated indicates an expected call of LifecycleOnUpdated.
+func (mr *MockSourceMockRecorder) LifecycleOnUpdated(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LifecycleOnUpdated", reflect.TypeOf((*MockSource)(nil).LifecycleOnUpdated), arg0, arg1, arg2)
+}
+
 // Open mocks base method.
 func (m *MockSource) Open(arg0 context.Context, arg1 Position) error {
 	m.ctrl.T.Helper()

--- a/source.go
+++ b/source.go
@@ -95,7 +95,7 @@ type Source interface {
 	// skipped if the connector configuration did not change. It can be used to
 	// update anything that was initialized in LifecycleOnCreated, in case the
 	// configuration change affects it.
-	LifecycleOnUpdated(ctx context.Context, configBefore map[string]string, configAfter map[string]string) error
+	LifecycleOnUpdated(ctx context.Context, configBefore, configAfter map[string]string) error
 	// LifecycleOnDeleted is called when the connector was deleted. It will be
 	// the only method that is called in that case. This method can be used to
 	// clean up anything that was initialized in LifecycleOnCreated.

--- a/source_test.go
+++ b/source_test.go
@@ -255,6 +255,58 @@ func TestSourcePluginAdapter_Teardown(t *testing.T) {
 	<-runDone
 }
 
+func TestSourcePluginAdapter_LifecycleOnCreated(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	src := NewMockSource(ctrl)
+
+	srcPlugin := NewSourcePlugin(src).(*sourcePluginAdapter)
+
+	want := map[string]string{"foo": "bar"}
+	src.EXPECT().LifecycleOnCreated(ctx, want).Return(nil)
+
+	req := cpluginv1.SourceLifecycleOnCreatedRequest{Config: want}
+	_, err := srcPlugin.LifecycleOnCreated(ctx, req)
+	is.NoErr(err)
+}
+
+func TestSourcePluginAdapter_LifecycleOnUpdated(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	src := NewMockSource(ctrl)
+
+	srcPlugin := NewSourcePlugin(src).(*sourcePluginAdapter)
+
+	wantBefore := map[string]string{"foo": "bar"}
+	wantAfter := map[string]string{"foo": "baz"}
+	src.EXPECT().LifecycleOnUpdated(ctx, wantBefore, wantAfter).Return(nil)
+
+	req := cpluginv1.SourceLifecycleOnUpdatedRequest{
+		ConfigBefore: wantBefore,
+		ConfigAfter:  wantAfter,
+	}
+	_, err := srcPlugin.LifecycleOnUpdated(ctx, req)
+	is.NoErr(err)
+}
+
+func TestSourcePluginAdapter_LifecycleOnDeleted(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	src := NewMockSource(ctrl)
+
+	srcPlugin := NewSourcePlugin(src).(*sourcePluginAdapter)
+
+	want := map[string]string{"foo": "bar"}
+	src.EXPECT().LifecycleOnDeleted(ctx, want).Return(nil)
+
+	req := cpluginv1.SourceLifecycleOnDeletedRequest{Config: want}
+	_, err := srcPlugin.LifecycleOnDeleted(ctx, req)
+	is.NoErr(err)
+}
+
 func newSourceRunStreamMock(
 	ctrl *gomock.Controller,
 ) (

--- a/unimplemented.go
+++ b/unimplemented.go
@@ -43,6 +43,22 @@ func (UnimplementedDestination) Write(context.Context, []Record) (int, error) {
 func (UnimplementedDestination) Teardown(context.Context) error {
 	return ErrUnimplemented
 }
+
+// LifecycleOnCreated won't do anything by default.
+func (UnimplementedDestination) LifecycleOnCreated(context.Context, map[string]string) error {
+	return nil
+}
+
+// LifecycleOnUpdated won't do anything by default.
+func (UnimplementedDestination) LifecycleOnUpdated(context.Context, map[string]string, map[string]string) error {
+	return nil
+}
+
+// LifecycleOnDeleted won't do anything by default.
+func (UnimplementedDestination) LifecycleOnDeleted(context.Context, map[string]string) error {
+	return nil
+}
+
 func (UnimplementedDestination) mustEmbedUnimplementedDestination() {}
 
 // UnimplementedSource should be embedded to have forward compatible implementations.
@@ -78,4 +94,20 @@ func (UnimplementedSource) Ack(context.Context, Position) error {
 func (UnimplementedSource) Teardown(context.Context) error {
 	return ErrUnimplemented
 }
+
+// LifecycleOnCreated won't do anything by default.
+func (UnimplementedSource) LifecycleOnCreated(context.Context, map[string]string) error {
+	return nil
+}
+
+// LifecycleOnUpdated won't do anything by default.
+func (UnimplementedSource) LifecycleOnUpdated(context.Context, map[string]string, map[string]string) error {
+	return nil
+}
+
+// LifecycleOnDeleted won't do anything by default.
+func (UnimplementedSource) LifecycleOnDeleted(context.Context, map[string]string) error {
+	return nil
+}
+
 func (UnimplementedSource) mustEmbedUnimplementedSource() {}


### PR DESCRIPTION
### Description

This PR is the follow-up to https://github.com/ConduitIO/conduit-connector-protocol/pull/22, where connector lifecycle events were added to the connector protocol. In this PR we expose those methods to connectors so they can react to those events.

Fixes https://github.com/ConduitIO/conduit/issues/936.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
