### PR TITLE
Destination record batching

### DIFF
--- a/destination.go
+++ b/destination.go
@@ -425,6 +425,10 @@ func (w *writeStrategyBatch) Write(ctx context.Context, r Record, ack func(error
 		// the flush happened just before enqueuing this record.
 		select {
 		case result := <-w.batcher.Results():
+			Logger(ctx).Debug().
+				Int("batchSize", result.Size).
+				Time("at", result.At).Err(result.Err).
+				Msg("last batch was flushed asynchronously")
 			if result.Err != nil {
 				return fmt.Errorf("last batch write failed: %w", result.Err)
 			}

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -35,7 +35,7 @@ func DefaultDestinationMiddleware() []DestinationMiddleware {
 	return []DestinationMiddleware{
 		DestinationWithRateLimit{},
 		DestinationWithRecordFormat{},
-		// DestinationWithBatch{}, // TODO enable batch middleware once batching is implemented
+		DestinationWithBatch{},
 	}
 }
 

--- a/internal/batcher.go
+++ b/internal/batcher.go
@@ -1,0 +1,96 @@
+// Copyright © 2023 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sync"
+	"time"
+)
+
+type Batcher[T any] struct {
+	sizeThreshold  int
+	delayThreshold time.Duration
+	fn             BatchFn[T]
+
+	batch      []T
+	results    []chan error
+	flushTimer *time.Timer
+	m          sync.Mutex
+}
+
+type BatchFn[T any] func([]T) error
+
+type (
+	EnqueueResult interface{ enqueueResult() }
+	Scheduled     struct{ Err <-chan error }
+	Flushed       struct{ Err error }
+)
+
+func (Scheduled) enqueueResult() {}
+func (Flushed) enqueueResult()   {}
+
+func NewBatcher[T any](sizeThreshold int, delayThreshold time.Duration, fn BatchFn[T]) *Batcher[T] {
+	return &Batcher[T]{
+		sizeThreshold:  sizeThreshold,
+		delayThreshold: delayThreshold,
+		fn:             fn,
+	}
+}
+
+func (b *Batcher[T]) Enqueue(item T) EnqueueResult {
+	b.m.Lock()
+	defer b.m.Unlock()
+
+	result := make(chan error, 1)
+	b.batch = append(b.batch, item)
+	b.results = append(b.results, result)
+
+	if len(b.batch) == b.sizeThreshold {
+		// trigger flush synchronously
+		b.flushNow()
+		return Flushed{Err: <-result}
+	}
+	if b.flushTimer == nil {
+		b.flushTimer = time.AfterFunc(b.delayThreshold, b.Flush)
+	}
+	return Scheduled{Err: result}
+}
+
+func (b *Batcher[T]) Flush() {
+	b.m.Lock()
+	defer b.m.Unlock()
+	b.flushNow()
+}
+
+func (b *Batcher[T]) flushNow() {
+	if b.flushTimer != nil {
+		b.flushTimer.Stop()
+		b.flushTimer = nil
+	}
+	if len(b.batch) == 0 {
+		// nothing to flush
+		return
+	}
+	batchCopy := make([]T, len(b.batch))
+	copy(batchCopy, b.batch)
+
+	err := b.fn(batchCopy)
+	for _, c := range b.results {
+		c <- err
+	}
+
+	b.batch = b.batch[:0]
+	b.results = b.results[:0]
+}

--- a/internal/batcher.go
+++ b/internal/batcher.go
@@ -15,7 +15,10 @@
 package internal
 
 import (
+	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -24,73 +27,114 @@ type Batcher[T any] struct {
 	delayThreshold time.Duration
 	fn             BatchFn[T]
 
-	batch      []T
-	results    []chan error
+	batch      chan T // batch collects elements of a batch
 	flushTimer *time.Timer
-	m          sync.Mutex
+	flushedAt  time.Time
+	m          sync.Mutex // m gets locked when a flush is triggered
+
+	stop    chan struct{}
+	stopped chan struct{}
+	flush   chan struct{}
+	errors  chan error
 }
 
 type BatchFn[T any] func([]T) error
 
-type (
-	EnqueueResult interface{ enqueueResult() }
-	Scheduled     struct{ Err <-chan error }
-	Flushed       struct{ Err error }
+type EnqueueResult int
+
+const (
+	Scheduled EnqueueResult = iota + 1
+	Flushed
 )
 
-func (Scheduled) enqueueResult() {}
-func (Flushed) enqueueResult()   {}
-
 func NewBatcher[T any](sizeThreshold int, delayThreshold time.Duration, fn BatchFn[T]) *Batcher[T] {
+	if sizeThreshold < 2 {
+		panic(fmt.Errorf("batch size threshold must be at least 2, got %d", sizeThreshold))
+	}
+
+	status := atomic.Value{}
+	status.Store(Scheduled)
 	return &Batcher[T]{
 		sizeThreshold:  sizeThreshold,
 		delayThreshold: delayThreshold,
+		batch:          make(chan T),
+		errors:         make(chan error, 1),
+		flush:          make(chan struct{}),
 		fn:             fn,
 	}
 }
 
-func (b *Batcher[T]) Enqueue(item T) EnqueueResult {
+func (b *Batcher[T]) Start() error {
 	b.m.Lock()
 	defer b.m.Unlock()
 
-	result := make(chan error, 1)
-	b.batch = append(b.batch, item)
-	b.results = append(b.results, result)
+	if b.stop != nil {
+		return errors.New("batcher already started")
+	}
+	b.stop = make(chan struct{})
+	b.stopped = make(chan struct{})
+	go func() {
+		batch := make([]T, 0, b.sizeThreshold)
+		var flushTimer *time.Timer
+		var flushTimerC <-chan time.Time
+		for {
+			select {
+			case <-b.stop:
+				b.m.Lock()
+				b.stop = nil
+				close(b.stopped)
+				b.m.Unlock()
+				return
 
-	if len(b.batch) == b.sizeThreshold {
-		// trigger flush synchronously
-		b.flushNow()
-		return Flushed{Err: <-result}
+			case item := <-b.batch:
+				batch = append(batch, item)
+				switch len(batch) {
+				case 1:
+					// start timer for flush
+					flushTimer = time.NewTimer(b.delayThreshold)
+					flushTimerC = flushTimer.C
+				}
+				if len(batch) == b.sizeThreshold {
+					flushTimer.Stop()
+					b.errors <- b.fn(batch)
+				}
+			case <-flushTimerC:
+				flushTimer.Stop()
+				b.errors <- b.fn(batch)
+			case <-b.flush:
+				flushTimer.Stop()
+				b.errors <- b.fn(batch)
+			}
+		}
+	}()
+	return nil
+}
+
+func (b *Batcher[T]) Stop() {
+	b.m.Lock()
+	if b.stop == nil {
+		b.m.Unlock()
+		return // batcher is not started
 	}
-	if b.flushTimer == nil {
-		b.flushTimer = time.AfterFunc(b.delayThreshold, b.Flush)
+	select {
+	case <-b.stop:
+		// stop already closed
+	default:
+		close(b.stop)
 	}
-	return Scheduled{Err: result}
+	b.m.Unlock()
+
+	<-b.stopped
+}
+
+func (b *Batcher[T]) Enqueue(item T) {
+	b.batch <- item
 }
 
 func (b *Batcher[T]) Flush() {
-	b.m.Lock()
-	defer b.m.Unlock()
-	b.flushNow()
+	b.flush <- struct{}{}
 }
 
-func (b *Batcher[T]) flushNow() {
-	if b.flushTimer != nil {
-		b.flushTimer.Stop()
-		b.flushTimer = nil
-	}
-	if len(b.batch) == 0 {
-		// nothing to flush
-		return
-	}
-	batchCopy := make([]T, len(b.batch))
-	copy(batchCopy, b.batch)
-
-	err := b.fn(batchCopy)
-	for _, c := range b.results {
-		c <- err
-	}
-
-	b.batch = b.batch[:0]
-	b.results = b.results[:0]
+func (b *Batcher[T]) Errors() chan error {
+	return b.errors
 }

--- a/internal/batcher_test.go
+++ b/internal/batcher_test.go
@@ -1,0 +1,240 @@
+// Copyright © 2023 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func BenchmarkBatcher_Enqueue(b *testing.B) {
+	batcher := NewBatcher(
+		1000,
+		time.Second,
+		func(batch []int) error { return nil },
+	)
+
+	var er EnqueueResult
+	for i := 0; i < b.N; i++ {
+		er = batcher.Enqueue(i)
+	}
+	_ = er
+}
+
+func TestBatcher_Enqueue_Scheduled(t *testing.T) {
+	is := is.New(t)
+	var gotBatches [][]int
+
+	b := NewBatcher(
+		2,
+		time.Second,
+		func(batch []int) error {
+			gotBatches = append(gotBatches, batch)
+			return nil
+		},
+	)
+
+	result := b.Enqueue(1)
+	rs, ok := result.(Scheduled)
+	is.True(ok)
+	select {
+	case <-rs.Err:
+		t.Fatal("did not expect the channel to contain a value")
+	default:
+		// all good
+	}
+	is.Equal(len(gotBatches), 0) // did not expect any batch to be executed
+}
+
+func TestBatcher_Enqueue_Flushed(t *testing.T) {
+	is := is.New(t)
+	var gotBatches [][]int
+
+	b := NewBatcher(
+		2,
+		time.Second,
+		func(batch []int) error {
+			gotBatches = append(gotBatches, batch)
+			return nil
+		},
+	)
+
+	result := b.Enqueue(1) // first item gets scheduled
+	rs, ok := result.(Scheduled)
+	is.True(ok)
+
+	result = b.Enqueue(2) // second item triggers a flush
+	rf, ok := result.(Flushed)
+	is.True(ok)
+	is.NoErr(rf.Err)
+
+	// the scheduled result should contain the same error, i.e. nil
+	select {
+	case err := <-rs.Err:
+		is.NoErr(err)
+	default:
+		t.Fatal("expected the channel to contain a value")
+	}
+
+	is.Equal(len(gotBatches), 1)
+	is.Equal(gotBatches[0], []int{1, 2})
+}
+
+func TestBatcher_Enqueue_Delay(t *testing.T) {
+	is := is.New(t)
+	var gotBatches [][]int
+	const wantDelay = time.Millisecond * 10
+
+	b := NewBatcher(
+		2,
+		wantDelay,
+		func(batch []int) error {
+			gotBatches = append(gotBatches, batch)
+			return nil
+		},
+	)
+
+	start := time.Now()
+	result := b.Enqueue(1) // first item gets scheduled
+	rs, ok := result.(Scheduled)
+	is.True(ok)
+
+	select {
+	case err := <-rs.Err:
+		is.NoErr(err)
+		is.True(time.Since(start) >= wantDelay)
+		is.Equal(len(gotBatches), 1)
+		is.Equal(gotBatches[0], []int{1, 2})
+	case <-time.After(wantDelay + time.Millisecond*5):
+		t.Fatal("expected the channel to contain a value after delay")
+	}
+
+	result = b.Enqueue(1) // next item gets scheduled again
+	_, ok = result.(Scheduled)
+	is.True(ok)
+}
+
+func TestBatcher_Enqueue_FlushedError(t *testing.T) {
+	is := is.New(t)
+	wantErr := errors.New("test error")
+
+	b := NewBatcher(
+		2,
+		time.Second,
+		func(batch []int) error {
+			return wantErr
+		},
+	)
+
+	result := b.Enqueue(1) // first item gets scheduled
+	rs, ok := result.(Scheduled)
+	is.True(ok)
+
+	result = b.Enqueue(2) // second item triggers a flush
+	rf, ok := result.(Flushed)
+	is.True(ok)
+	is.Equal(wantErr, rf.Err)
+
+	select {
+	case err := <-rs.Err:
+		is.Equal(wantErr, err)
+	default:
+		t.Fatal("expected the channel to contain a value")
+	}
+}
+
+func TestBatcher_Flush(t *testing.T) {
+	is := is.New(t)
+	var gotBatches [][]int
+
+	b := NewBatcher(
+		10,
+		time.Second,
+		func(batch []int) error {
+			gotBatches = append(gotBatches, batch)
+			return nil
+		},
+	)
+
+	var results []Scheduled
+	for i := 0; i < 9; i++ {
+		result := b.Enqueue(i)
+		results = append(results, result.(Scheduled))
+	}
+
+	is.Equal(len(gotBatches), 0)
+	b.Flush()
+
+	is.Equal(len(gotBatches), 1)
+	is.Equal(gotBatches[0], []int{0, 1, 2, 3, 4, 5, 6, 7, 8})
+
+	for _, rs := range results {
+		select {
+		case err := <-rs.Err:
+			is.NoErr(err)
+		default:
+			t.Fatal("expected the channel to contain a value")
+		}
+	}
+}
+
+func TestBatcher_Concurrent(t *testing.T) {
+	is := is.New(t)
+	var gotBatches [][]int
+	const workers = 100
+	const batchSize = 5
+
+	b := NewBatcher(
+		batchSize,
+		time.Second,
+		func(batch []int) error {
+			gotBatches = append(gotBatches, batch)
+			return nil
+		},
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(c int) {
+			defer wg.Done()
+			var results []EnqueueResult
+			for i := 0; i < batchSize; i++ {
+				r := b.Enqueue(c*batchSize + i)
+				results = append(results, r)
+			}
+			for _, r := range results {
+				switch r := r.(type) {
+				case Scheduled:
+					is.NoErr(<-r.Err)
+				case Flushed:
+					is.NoErr(r.Err)
+				default:
+					t.Fatal("unknown result type")
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	is.Equal(len(gotBatches), workers)
+	for _, gotBatch := range gotBatches {
+		is.Equal(len(gotBatch), batchSize)
+	}
+}

--- a/internal/batcher_test.go
+++ b/internal/batcher_test.go
@@ -190,7 +190,6 @@ func TestBatcher_Flush(t *testing.T) {
 	default:
 		t.Fatal("expected the channel to contain a value")
 	}
-
 }
 
 func TestBatcher_Concurrent(t *testing.T) {

--- a/kafkaconnect/reflect.go
+++ b/kafkaconnect/reflect.go
@@ -129,6 +129,7 @@ func reflectInternal(v reflect.Value, t reflect.Type) *Schema {
 		for _, kv := range v.MapKeys() {
 			keyValue = kv
 			valValue = v.MapIndex(kv)
+			break
 		}
 		return &Schema{
 			Type:   TypeMap,

--- a/source.go
+++ b/source.go
@@ -360,7 +360,8 @@ func (a *sourcePluginAdapter) convertData(d Data) cpluginv1.Data {
 	}
 }
 
-// SourceUtil provides utility methods for implementing a source.
+// SourceUtil provides utility methods for implementing a source. Use it by
+// calling Util.Source.*.
 type SourceUtil struct{}
 
 // NewRecordCreate can be used to instantiate a record with OperationCreate.


### PR DESCRIPTION
### Description

Implements record batching in destinations. Batching can be turned on using the connector config options `sdk.batch.size` and `sdk.batch.delay`, e.g.:

```
sdk.batch.size: 10000 # trigger batch when 10000 records are collected
sdk.batch.delay: 2s   # trigger batch after 2 seconds even if it didn't reach the full size
```

Fixes #74 

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
