### PR TITLE
Check for open and read in teardown

### DIFF
--- a/source.go
+++ b/source.go
@@ -270,8 +270,13 @@ func (a *sourcePluginAdapter) Stop(ctx context.Context, _ cpluginv1.SourceStopRe
 func (a *sourcePluginAdapter) Teardown(ctx context.Context, _ cpluginv1.SourceTeardownRequest) (cpluginv1.SourceTeardownResponse, error) {
 	// cancel open and read context, in case Stop was not called (can happen in
 	// case the stop was triggered by an error)
-	a.openCancel()
-	a.readCancel()
+	// teardown can be called without "open" or read
+	if a.openCancel != nil {
+		a.openCancel()
+	}
+	if a.readCancel != nil {
+		a.readCancel()
+	}
 
 	var waitErr error
 	if a.t != nil {

--- a/source.go
+++ b/source.go
@@ -270,7 +270,9 @@ func (a *sourcePluginAdapter) Stop(ctx context.Context, _ cpluginv1.SourceStopRe
 func (a *sourcePluginAdapter) Teardown(ctx context.Context, _ cpluginv1.SourceTeardownRequest) (cpluginv1.SourceTeardownResponse, error) {
 	// cancel open and read context, in case Stop was not called (can happen in
 	// case the stop was triggered by an error)
-	// teardown can be called without "open" or read
+	// teardown can be called without "open" or "read" being called previously
+	// e.g. when Conduit is validating a connector configuration,
+	// it will call "configure" and then "teardown".
 	if a.openCancel != nil {
 		a.openCancel()
 	}


### PR DESCRIPTION
### Description

Since #77 we cancel the Open and Read contexts in Teardown. However, the context cancellation functions may not have been set (e.g. when creating connectors through the API/UI, a connector configuration is validated by calling `Configure` and then `Teardown`).  

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
