### PR TITLE
[WIP] Utility for generating readme from specifications

### DIFF
--- a/cmd/readmegen/main.go
+++ b/cmd/readmegen/main.go
@@ -1,0 +1,164 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"text/template"
+
+	"github.com/conduitio/conduit-connector-sdk/cmd/readmegen/util"
+	"golang.org/x/mod/modfile"
+)
+
+var (
+	pkg               = flag.String("package", "", "The full package import path for the connector. By default, readmegen will try to detect the package import path based on the go.mod file it finds in the directory or any parent directory.")
+	debugIntermediary = flag.Bool("debug-intermediary", false, "Print the intermediary generated program to stdout instead of writing it to a file")
+	yaml              = flag.Bool("yaml", false, "Generate parameters in YAML format (default is a HTML table)")
+)
+
+func main() {
+	flag.Parse()
+
+	if *pkg == "" {
+		var err error
+		*pkg, err = detectPackage()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+
+	err := generate()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func detectPackage() (string, error) {
+	currentDir, err := filepath.Abs(".")
+	if err != nil {
+		return "", fmt.Errorf("could not detect absolute path to current directory: %w", err)
+	}
+	for {
+		dat, err := os.ReadFile(filepath.Join(currentDir, "go.mod"))
+		if os.IsNotExist(err) {
+			if currentDir == filepath.Dir(currentDir) {
+				// at the root
+				break
+			}
+			currentDir = filepath.Dir(currentDir)
+			continue
+		} else if err != nil {
+			return "", err
+		}
+		modulePath := modfile.ModulePath(dat)
+		if modulePath == "" {
+			break // no module path found
+		}
+		return modulePath, nil
+	}
+	return "", errors.New("could not detect package, make sure you are in the root of the connector directory or provide the -package flag manually")
+}
+
+func generate() (err error) {
+	if *debugIntermediary {
+		return executeTemplate(os.Stdout)
+	}
+
+	tmpDir, err := os.MkdirTemp(".", "readmegen_tmp")
+	if err != nil {
+		return fmt.Errorf("could not create temporary directory: %w", err)
+	}
+	defer func() {
+		removeErr := os.RemoveAll(tmpDir)
+		if removeErr != nil {
+			removeErr = fmt.Errorf("could not remove temporary directory: %w", removeErr)
+			err = errors.Join(err, removeErr)
+		}
+	}()
+
+	f, err := os.Create(filepath.Join(tmpDir, "main.go"))
+	if err != nil {
+		return fmt.Errorf("could not create temporary file: %w", err)
+	}
+	defer f.Close()
+
+	err = executeTemplate(f)
+	if err != nil {
+		return fmt.Errorf("could not execute template: %w", err)
+	}
+	f.Close()
+
+	cmd := exec.Command("go", "run", "main.go")
+	cmd.Dir = tmpDir
+	cmd.Stdout = os.Stdout // pipe directly to stdout
+	cmd.Stderr = os.Stderr // pipe directly to stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("intermediary program failed: %w", err)
+	}
+
+	return nil
+}
+
+func executeTemplate(out io.Writer) error {
+	t, err := template.New("").Parse(tmpl)
+	if err != nil {
+		return fmt.Errorf("could not parse template: %w", err)
+	}
+	return t.Execute(out, data{
+		ImportPath: *pkg,
+		GenerateOptions: util.GenerateOptions{
+			YAMLParameters: *yaml,
+		},
+	})
+}
+
+type data struct {
+	ImportPath      string
+	GenerateOptions util.GenerateOptions
+}
+
+const tmpl = `
+package main
+
+import (
+	"fmt"
+	"os"
+
+	conn "{{ .ImportPath }}"
+	"github.com/conduitio/conduit-connector-sdk/cmd/readmegen/util"
+)
+
+func main() {
+	err := util.Generate(
+		conn.Connector,
+		util.GenerateOptions{
+			YAMLParameters: {{ printf "%#v" .GenerateOptions.YAMLParameters }},
+			Output:         os.Stdout,
+		},
+	)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+`

--- a/cmd/readmegen/util/parameters.table.tmpl
+++ b/cmd/readmegen/util/parameters.table.tmpl
@@ -1,0 +1,20 @@
+{{ define "parameters" -}}
+<table class="no-margin-table">
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Default</th>
+    <th>Description</th>
+  </tr>
+  {{- range $name, $param := .parameters }}
+  <tr>
+    <td>`{{ $name }}`</td>
+    <td>{{ $param.Type }}</td>
+    <td>`{{ $param.Default }}`</td>
+    <td>
+{{ $param.Description }}
+    </td>
+  </tr>
+  {{- end }}
+</table>
+{{- end }}

--- a/cmd/readmegen/util/parameters.yaml.tmpl
+++ b/cmd/readmegen/util/parameters.yaml.tmpl
@@ -1,0 +1,17 @@
+{{ define "parameters" }}
+```yaml
+version: 2.2
+pipelines:
+  - id: example
+    status: running
+    connectors:
+      - id: example
+        plugin: "{{ .specification.Name }}"
+        settings:
+        {{- range $name, $param := .parameters }}
+          {{ formatCommentYAML $param.Description 10 }}
+          # Type: {{ $param.Type }}
+          {{ $name }}: "{{ $param.Default }}"
+        {{- end }}
+```
+{{- end }}

--- a/cmd/readmegen/util/readme.tmpl
+++ b/cmd/readmegen/util/readme.tmpl
@@ -1,0 +1,19 @@
+# Conduit Connector {{ title .specification.Name }}
+
+{{ if .specification.Description -}}
+  {{ .specification.Description }}
+{{ else -}}
+  {{ .specification.Summary }}
+{{- end }}
+
+## Source
+
+### Configuration Parameters
+
+{{ template "parameters" args "specification" .specification "parameters" .sourceParams }}
+
+## Destination
+
+### Configuration Parameters
+
+{{ template "parameters" args "specification" .specification "parameters" .destinationParams }}

--- a/cmd/readmegen/util/util.go
+++ b/cmd/readmegen/util/util.go
@@ -1,0 +1,141 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	_ "embed"
+	"errors"
+	"io"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	sdk "github.com/conduitio/conduit-connector-sdk"
+)
+
+var (
+	//go:embed readme.tmpl
+	readmeTmpl string
+	//go:embed parameters.table.tmpl
+	parametersTableTmpl string
+	//go:embed parameters.yaml.tmpl
+	parametersYAMLTmpl string
+)
+
+type GenerateOptions struct {
+	YAMLParameters bool
+	Output         io.Writer
+}
+
+func Generate(conn sdk.Connector, opts GenerateOptions) error {
+	templates := []string{readmeTmpl, parametersTableTmpl}
+	if opts.YAMLParameters {
+		// switch table template to YAML template
+		templates[1] = parametersYAMLTmpl
+	}
+	t := template.Must(
+		template.New("readme").
+			Funcs(funcMap).
+			Funcs(sprig.FuncMap()).
+			Parse(strings.Join(templates, "\n")),
+	)
+	err := t.Execute(opts.Output, map[string]any{
+		"specification":     conn.NewSpecification(),
+		"sourceParams":      conn.NewSource().Parameters(),
+		"destinationParams": conn.NewDestination().Parameters(),
+	})
+	return err
+}
+
+var funcMap = template.FuncMap{
+	"formatCommentYAML": formatCommentYAML,
+	"args":              args,
+}
+
+func args(kvs ...any) (map[string]any, error) {
+	if len(kvs)%2 != 0 {
+		return nil, errors.New("args requires even number of arguments")
+	}
+	m := make(map[string]any)
+	for i := 0; i < len(kvs); i += 2 {
+		s, ok := kvs[i].(string)
+		if !ok {
+			return nil, errors.New("even args must be strings")
+		}
+		m[s] = kvs[i+1]
+	}
+	return m, nil
+}
+
+// formatCommentYAML takes a markdown text and formats it as a comment in a YAML
+// file. The comment is prefixed with the given indent level and "# ". The lines
+// are wrapped at 80 characters.
+func formatCommentYAML(text string, indent int) string {
+	const (
+		prefix     = "# "
+		lineLen    = 80
+		tmpNewLine = "〠"
+	)
+
+	// remove markdown new lines
+	text = strings.ReplaceAll(text, "\n\n", tmpNewLine)
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = strings.ReplaceAll(text, tmpNewLine, "\n")
+
+	comment := formatMultiline(text, strings.Repeat(" ", indent)+prefix, lineLen)
+	// remove first indent and last new line
+	comment = comment[indent : len(comment)-1]
+	return comment
+}
+
+func formatMultiline(
+	input string,
+	prefix string,
+	maxLineLen int,
+) string {
+	textLen := maxLineLen - len(prefix)
+
+	// split the input into lines of length textLen
+	lines := strings.Split(input, "\n")
+	var formattedLines []string
+	for _, line := range lines {
+		if len(line) <= textLen {
+			formattedLines = append(formattedLines, line)
+			continue
+		}
+
+		// split the line into multiple lines, don't break words
+		words := strings.Fields(line)
+		var formattedLine string
+		for _, word := range words {
+			if len(formattedLine)+len(word) > textLen {
+				formattedLines = append(formattedLines, formattedLine[1:])
+				formattedLine = ""
+			}
+			formattedLine += " " + word
+		}
+		if formattedLine != "" {
+			formattedLines = append(formattedLines, formattedLine[1:])
+		}
+	}
+
+	// combine lines including indent and prefix
+	var formatted string
+	for _, line := range formattedLines {
+		formatted += prefix + line + "\n"
+	}
+
+	return formatted
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/exp v0.0.0-20221114191408-850992195362
+	golang.org/x/mod v0.8.0
 	golang.org/x/time v0.5.0
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 )

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
### Description

This PR contains an experimental utility `readmegen` that uses the connector specification to generate the connector readme. The specification contains a lot of useful information about how to configure the connector, but it's not enough to generate the full readme, as there might be intricacies that the user wants to add. Still, this could be a useful tool to generate the configuration info and keep it up to date.

Why WIP? We need to figure out how this could fit in the development flow of implementing a connector. Ideally we should be able to trigger a make target that outputs the updated readme, without the need to manually add more stuff. This would allow us to run it as part of a CI action that checks if generated files are up to date ([example](https://github.com/ConduitIO/conduit-commons/blob/main/.github/workflows/validate-generated-files.yml)), this way we'd ensure that the readme contains the newest information after an update of the SDK or after we change some configuration parameters.