### PR TITLE
Ignore files marked with go:build tools

### DIFF
--- a/cmd/paramgen/internal/paramgen.go
+++ b/cmd/paramgen/internal/paramgen.go
@@ -126,11 +126,9 @@ func parsePackage(path string) (*ast.Package, error) {
 	// Ignore files with go:build constraint set to "tools" (common pattern in
 	// Conduit connectors).
 	for pkgName, pkg := range pkgs {
-		for fileName, f := range pkg.Files {
-			if hasBuildConstraint(f, "tools") {
-				delete(pkg.Files, fileName)
-			}
-		}
+		maps.DeleteFunc(pkg.Files, func(_ string, f *ast.File) bool {
+			return hasBuildConstraint(f, "tools")
+		})
 		if len(pkg.Files) == 0 {
 			delete(pkgs, pkgName)
 		}

--- a/cmd/paramgen/internal/testdata/complex/tools.go
+++ b/cmd/paramgen/internal/testdata/complex/tools.go
@@ -1,0 +1,19 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build tools
+
+// This file should be ignored because of the build tag.
+
+package main


### PR DESCRIPTION
### Description

A naive check to ignore files containing the comment `//go:build tools`, which are commonly found in Conduit connectors and can cause issues with paramgen.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
