### PR TITLE
Add `before` to new record util.

### DIFF
--- a/source.go
+++ b/source.go
@@ -469,6 +469,7 @@ func (SourceUtil) NewRecordDelete(
 	position opencdc.Position,
 	metadata opencdc.Metadata,
 	key opencdc.Data,
+	payloadBefore opencdc.Data,
 ) opencdc.Record {
 	if metadata == nil {
 		metadata = make(map[string]string)
@@ -479,5 +480,8 @@ func (SourceUtil) NewRecordDelete(
 		Operation: opencdc.OperationDelete,
 		Metadata:  metadata,
 		Key:       key,
+		Payload: opencdc.Change{
+			Before: payloadBefore,
+		},
 	}
 }


### PR DESCRIPTION
### Description

Some systems emit the old values when a record is deleted. This helper is extended to allow for this.


### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
