### PR TITLE
Destination middleware for decoding data with attached schema

### DIFF
--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -65,8 +65,9 @@ func DefaultDestinationMiddleware(opts ...DestinationMiddlewareOption) []Destina
 
 // DestinationWithMiddleware wraps the destination into the supplied middleware.
 func DestinationWithMiddleware(d Destination, middleware ...DestinationMiddleware) Destination {
-	for _, m := range middleware {
-		d = m.Wrap(d)
+	// apply middleware in reverse order to preserve the order as specified
+	for i := len(middleware) - 1; i >= 0; i-- {
+		d = middleware[i].Wrap(d)
 	}
 	return d
 }

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -633,6 +633,9 @@ func (d *destinationWithSchemaExtraction) Write(ctx context.Context, records []o
 	if d.keyEnabled {
 		for i := range records {
 			if err := d.decodeKey(ctx, &records[i]); err != nil {
+				if len(records) > 0 {
+					err = fmt.Errorf("record %d: %w", i, err)
+				}
 				return 0, err
 			}
 		}
@@ -640,6 +643,9 @@ func (d *destinationWithSchemaExtraction) Write(ctx context.Context, records []o
 	if d.payloadEnabled {
 		for i := range records {
 			if err := d.decodePayload(ctx, &records[i]); err != nil {
+				if len(records) > 0 {
+					err = fmt.Errorf("record %d: %w", i, err)
+				}
 				return 0, err
 			}
 		}

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -665,11 +665,14 @@ func (d *destinationWithSchemaExtraction) decodeKey(ctx context.Context, rec *op
 		return fmt.Errorf("failed to get key schema version from metadata: %w", errVersion)
 	}
 
-	decodedKey, err := d.decode(ctx, rec.Key, subject, version)
-	if err != nil {
-		return fmt.Errorf("failed to decode key: %w", err)
+	if rec.Key != nil {
+		decodedKey, err := d.decode(ctx, rec.Key, subject, version)
+		if err != nil {
+			return fmt.Errorf("failed to decode key: %w", err)
+		}
+		rec.Key = decodedKey
 	}
-	rec.Key = decodedKey
+
 	return nil
 }
 
@@ -690,17 +693,21 @@ func (d *destinationWithSchemaExtraction) decodePayload(ctx context.Context, rec
 		return fmt.Errorf("failed to get payload schema version from metadata: %w", errVersion)
 	}
 
-	decodedPayloadBefore, err := d.decode(ctx, rec.Payload.Before, subject, version)
-	if err != nil {
-		return fmt.Errorf("failed to decode payload.before: %w", err)
+	if rec.Payload.Before != nil {
+		decodedPayloadBefore, err := d.decode(ctx, rec.Payload.Before, subject, version)
+		if err != nil {
+			return fmt.Errorf("failed to decode payload.before: %w", err)
+		}
+		rec.Payload.Before = decodedPayloadBefore
 	}
-	decodedPayloadAfter, err := d.decode(ctx, rec.Payload.After, subject, version)
-	if err != nil {
-		return fmt.Errorf("failed to decode payload.after: %w", err)
+	if rec.Payload.After != nil {
+		decodedPayloadAfter, err := d.decode(ctx, rec.Payload.After, subject, version)
+		if err != nil {
+			return fmt.Errorf("failed to decode payload.after: %w", err)
+		}
+		rec.Payload.After = decodedPayloadAfter
 	}
 
-	rec.Payload.Before = decodedPayloadBefore
-	rec.Payload.After = decodedPayloadAfter
 	return nil
 }
 
@@ -708,8 +715,6 @@ func (d *destinationWithSchemaExtraction) decode(ctx context.Context, data openc
 	switch data := data.(type) {
 	case opencdc.StructuredData:
 		return data, nil // already decoded
-	case nil:
-		return nil, nil //nolint:nilnil // nothing to decode
 	case opencdc.RawData: // let's decode it
 	default:
 		return nil, fmt.Errorf("unexpected data type %T", data)

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -26,7 +26,7 @@ import (
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-commons/schema"
-	sdkSchema "github.com/conduitio/conduit-connector-sdk/schema"
+	sdkschema "github.com/conduitio/conduit-connector-sdk/schema"
 	"golang.org/x/time/rate"
 )
 
@@ -725,7 +725,7 @@ func (d *destinationWithSchemaExtraction) decode(ctx context.Context, data openc
 		d.subjectVersionCache[subject] = make(map[int]schema.Schema)
 	}
 	if _, ok := d.subjectVersionCache[subject][version]; !ok {
-		sch, err := sdkSchema.Get(ctx, subject, version)
+		sch, err := sdkschema.Get(ctx, subject, version)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get schema for %s:%d: %w", subject, version, err)
 		}

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -658,17 +658,17 @@ func (d *destinationWithSchemaExtraction) decodeKey(ctx context.Context, rec *op
 	subject, errSubject := rec.Metadata.GetKeySchemaSubject()
 	version, errVersion := rec.Metadata.GetKeySchemaVersion()
 	switch {
-	case errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound) &&
+	case errSubject != nil && !errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound):
+		return fmt.Errorf("failed to get key schema subject from metadata: %w", errSubject)
+	case errVersion != nil && !errors.Is(errVersion, opencdc.ErrMetadataFieldNotFound):
+		return fmt.Errorf("failed to get key schema version from metadata: %w", errVersion)
+	case errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound) ||
 		errors.Is(errVersion, opencdc.ErrMetadataFieldNotFound):
 		// log warning once, to avoid spamming the logs
 		d.keyWarnOnce.Do(func() {
 			Logger(ctx).Warn().Msgf(`record does not have an attached schema for the key, consider disabling the destination schema key decoding using "%s: false"`, configDestinationWithSchemaExtractionKeyEnabled)
 		})
 		return nil
-	case errSubject != nil && !errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound):
-		return fmt.Errorf("failed to get key schema subject from metadata: %w", errSubject)
-	case errVersion != nil && !errors.Is(errVersion, opencdc.ErrMetadataFieldNotFound):
-		return fmt.Errorf("failed to get key schema version from metadata: %w", errVersion)
 	}
 
 	if rec.Key != nil {
@@ -686,17 +686,17 @@ func (d *destinationWithSchemaExtraction) decodePayload(ctx context.Context, rec
 	subject, errSubject := rec.Metadata.GetPayloadSchemaSubject()
 	version, errVersion := rec.Metadata.GetPayloadSchemaVersion()
 	switch {
-	case errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound) &&
+	case errSubject != nil && !errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound):
+		return fmt.Errorf("failed to get payload schema subject from metadata: %w", errSubject)
+	case errVersion != nil && !errors.Is(errVersion, opencdc.ErrMetadataFieldNotFound):
+		return fmt.Errorf("failed to get payload schema version from metadata: %w", errVersion)
+	case errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound) ||
 		errors.Is(errVersion, opencdc.ErrMetadataFieldNotFound):
 		// log warning once, to avoid spamming the logs
 		d.payloadWarnOnce.Do(func() {
 			Logger(ctx).Warn().Msgf(`record does not have an attached schema for the payload, consider disabling the destination schema payload decoding using "%s: false"`, configDestinationWithSchemaExtractionPayloadEnabled)
 		})
 		return nil
-	case errSubject != nil && !errors.Is(errSubject, opencdc.ErrMetadataFieldNotFound):
-		return fmt.Errorf("failed to get payload schema subject from metadata: %w", errSubject)
-	case errVersion != nil && !errors.Is(errVersion, opencdc.ErrMetadataFieldNotFound):
-		return fmt.Errorf("failed to get payload schema version from metadata: %w", errVersion)
 	}
 
 	if rec.Payload.Before != nil {

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -44,6 +44,7 @@ var (
 	_ DestinationMiddlewareOption = DestinationWithBatchConfig{}.Apply
 	_ DestinationMiddlewareOption = DestinationWithRecordFormatConfig{}.Apply
 	_ DestinationMiddlewareOption = DestinationWithRateLimitConfig{}.Apply
+	_ DestinationMiddlewareOption = DestinationWithSchemaExtractionConfig{}.Apply
 )
 
 // DefaultDestinationMiddleware returns a slice of middleware that should be
@@ -53,6 +54,7 @@ func DefaultDestinationMiddleware(opts ...DestinationMiddlewareOption) []Destina
 		&DestinationWithRateLimit{},
 		&DestinationWithRecordFormat{},
 		&DestinationWithBatch{},
+		&DestinationWithSchemaExtraction{},
 	}
 	// apply options to all middleware
 	for _, m := range middleware {

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -551,7 +551,20 @@ func (c DestinationWithSchemaExtractionConfig) parameters() config.Parameters {
 	}
 }
 
-// DestinationWithSchemaExtraction is a middleware that TODO.
+// DestinationWithSchemaExtraction is a middleware that extracts and decodes the
+// key and/or payload of a record using a schema. It takes the schema subject and
+// version from the record metadata, fetches the schema from the schema service,
+// and decodes the key and/or payload using the schema.
+// If the schema subject and version is not found in the record metadata, it will
+// log a warning and skip decoding the key and/or payload. This middleware is
+// useful when the source connector sends the data with the schema attached.
+// This middleware is the counterpart of SourceWithSchemaExtraction.
+//
+// It adds two parameters to the destination config:
+//   - `sdk.schema.extract.key.enabled` - Whether to extract and decode the
+//     record key with a schema.
+//   - `sdk.schema.extract.payload.enabled` - Whether to extract and decode the
+//     record payload with a schema.
 type DestinationWithSchemaExtraction struct {
 	Config DestinationWithSchemaExtractionConfig
 }

--- a/destination_middleware_test.go
+++ b/destination_middleware_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/conduitio/conduit-commons/schema/avro"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit-connector-sdk/internal"
-	sdkSchema "github.com/conduitio/conduit-connector-sdk/schema"
+	sdkschema "github.com/conduitio/conduit-connector-sdk/schema"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
 	"go.uber.org/mock/gomock"
@@ -480,7 +480,7 @@ func TestDestinationWithSchemaExtraction_Write(t *testing.T) {
 
 	srd, err := avro.SerdeForType(testStructuredData)
 	is.NoErr(err)
-	sch, err := sdkSchema.Create(ctx, schema.TypeAvro, "TestDestinationWithSchemaExtraction_Write", []byte(srd.String()))
+	sch, err := sdkschema.Create(ctx, schema.TypeAvro, "TestDestinationWithSchemaExtraction_Write", []byte(srd.String()))
 	is.NoErr(err)
 
 	b, err := sch.Marshal(testStructuredData)

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -39,8 +39,8 @@ func TestSourceWithSchemaExtraction(t *testing.T) {
 	is := is.New(t)
 
 	wantCfg := SourceWithSchemaExtractionConfig{
-		PayloadEnable:  ptr(true),
-		KeyEnable:      ptr(true),
+		PayloadEnabled: ptr(true),
+		KeyEnabled:     ptr(true),
 		PayloadSubject: ptr("foo"),
 		KeySubject:     ptr("bar"),
 	}
@@ -108,8 +108,8 @@ func TestSourceWithSchemaExtractionConfig_Configure(t *testing.T) {
 		name: "disabled by default",
 		middleware: SourceWithSchemaExtraction{
 			Config: SourceWithSchemaExtractionConfig{
-				PayloadEnable: ptr(false),
-				KeyEnable:     ptr(false),
+				PayloadEnabled: ptr(false),
+				KeyEnabled:     ptr(false),
 			},
 		},
 		have: config.Config{},
@@ -121,8 +121,8 @@ func TestSourceWithSchemaExtractionConfig_Configure(t *testing.T) {
 		name:       "disabled by config",
 		middleware: SourceWithSchemaExtraction{},
 		have: config.Config{
-			configSourceSchemaExtractionPayloadEncode: "false",
-			configSourceSchemaExtractionKeyEncode:     "false",
+			configSourceSchemaExtractionPayloadEnabled: "false",
+			configSourceSchemaExtractionKeyEnabled:     "false",
 		},
 
 		wantSchemaType:     schema.TypeAvro,
@@ -393,7 +393,7 @@ func TestSourceWithSchemaContext_Parameters(t *testing.T) {
 			name:  "default middleware config",
 			mwCfg: SourceWithSchemaContextConfig{},
 			wantParams: config.Parameters{
-				"sdk.schema.context.enable": {
+				"sdk.schema.context.enabled": {
 					Default: "true",
 					Description: "Specifies whether to use a schema context name. If set to false, no schema context name " +
 						"will be used, and schemas will be saved with the subject name specified in the connector " +
@@ -411,11 +411,11 @@ func TestSourceWithSchemaContext_Parameters(t *testing.T) {
 		{
 			name: "custom middleware config",
 			mwCfg: SourceWithSchemaContextConfig{
-				Enable: ptr(false),
-				Name:   ptr("foobar"),
+				Enabled: ptr(false),
+				Name:    ptr("foobar"),
 			},
 			wantParams: config.Parameters{
-				"sdk.schema.context.enable": {
+				"sdk.schema.context.enabled": {
 					Default: "false",
 					Description: "Specifies whether to use a schema context name. If set to false, no schema context name " +
 						"will be used, and schemas will be saved with the subject name specified in the connector " +
@@ -478,8 +478,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "custom context in middleware, no user config",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enable: ptr(true),
-				Name:   ptr("foobar"),
+				Enabled: ptr(true),
+				Name:    ptr("foobar"),
 			},
 			connectorCfg:    config.Config{},
 			wantContextName: "foobar",
@@ -487,8 +487,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "middleware config: use context false, no user config",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enable: ptr(false),
-				Name:   ptr("foobar"),
+				Enabled: ptr(false),
+				Name:    ptr("foobar"),
 			},
 			connectorCfg:    config.Config{},
 			wantContextName: "",
@@ -496,19 +496,19 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "user config overrides use context",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enable: ptr(false),
-				Name:   ptr("foobar"),
+				Enabled: ptr(false),
+				Name:    ptr("foobar"),
 			},
 			connectorCfg: config.Config{
-				"sdk.schema.context.enable": "true",
+				"sdk.schema.context.enabled": "true",
 			},
 			wantContextName: "foobar",
 		},
 		{
 			name: "user config overrides context name, non-empty",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enable: ptr(true),
-				Name:   ptr("foobar"),
+				Enabled: ptr(true),
+				Name:    ptr("foobar"),
 			},
 			connectorCfg: config.Config{
 				"sdk.schema.context.use":  "true",
@@ -519,8 +519,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "user config overrides context name, empty",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enable: ptr(true),
-				Name:   ptr("foobar"),
+				Enabled: ptr(true),
+				Name:    ptr("foobar"),
 			},
 			connectorCfg: config.Config{
 				"sdk.schema.context.use":  "true",

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -35,7 +35,7 @@ import (
 
 // -- SourceWithSchemaExtraction -----------------------------------------------
 
-func TestSourceWithSchemaExtraction(t *testing.T) {
+func TestSourceWithSchemaExtractionConfig_Apply(t *testing.T) {
 	is := is.New(t)
 
 	wantCfg := SourceWithSchemaExtractionConfig{
@@ -51,7 +51,7 @@ func TestSourceWithSchemaExtraction(t *testing.T) {
 	is.Equal(have.Config, wantCfg)
 }
 
-func TestSourceWithSchemaExtractionConfig_Parameters(t *testing.T) {
+func TestSourceWithSchemaExtraction_Parameters(t *testing.T) {
 	is := is.New(t)
 	ctrl := gomock.NewController(t)
 	src := NewMockSource(ctrl)
@@ -72,7 +72,7 @@ func TestSourceWithSchemaExtractionConfig_Parameters(t *testing.T) {
 	is.Equal(len(got), 6) // expected middleware to inject 5 parameters
 }
 
-func TestSourceWithSchemaExtractionConfig_Configure(t *testing.T) {
+func TestSourceWithSchemaExtraction_Configure(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	src := NewMockSource(ctrl)
 	ctx := context.Background()
@@ -176,7 +176,7 @@ func TestSourceWithSchemaExtractionConfig_Configure(t *testing.T) {
 	}
 }
 
-func TestSourceWithSchemaExtractionConfig_Read(t *testing.T) {
+func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 	is := is.New(t)
 	ctrl := gomock.NewController(t)
 	src := NewMockSource(ctrl)

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit-connector-sdk/internal"
-	sdkSchema "github.com/conduitio/conduit-connector-sdk/schema"
+	sdkschema "github.com/conduitio/conduit-connector-sdk/schema"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
@@ -326,7 +326,7 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				version, err := got.Metadata.GetKeySchemaVersion()
 				is.NoErr(err)
 
-				sch, err := sdkSchema.Get(ctx, subject, version)
+				sch, err := sdkschema.Get(ctx, subject, version)
 				is.NoErr(err)
 
 				var sd opencdc.StructuredData
@@ -349,7 +349,7 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				version, err := got.Metadata.GetPayloadSchemaVersion()
 				is.NoErr(err)
 
-				sch, err := sdkSchema.Get(ctx, subject, version)
+				sch, err := sdkschema.Get(ctx, subject, version)
 				is.NoErr(err)
 
 				if isPayloadBeforeStructured {
@@ -541,7 +541,7 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 			s.EXPECT().
 				Configure(gomock.Any(), tc.connectorCfg).
 				DoAndReturn(func(ctx context.Context, c config.Config) error {
-					gotContextName := sdkSchema.GetSchemaContextName(ctx)
+					gotContextName := sdkschema.GetSchemaContextName(ctx)
 					is.Equal(tc.wantContextName, gotContextName)
 					return nil
 				})
@@ -568,13 +568,13 @@ func TestSourceWithSchemaContext_ContextValue(t *testing.T) {
 	s.EXPECT().
 		Configure(gomock.Any(), connectorCfg).
 		DoAndReturn(func(ctx context.Context, _ config.Config) error {
-			is.Equal(wantContextName, sdkSchema.GetSchemaContextName(ctx))
+			is.Equal(wantContextName, sdkschema.GetSchemaContextName(ctx))
 			return nil
 		})
 	s.EXPECT().
 		Open(gomock.Any(), opencdc.Position{}).
 		DoAndReturn(func(ctx context.Context, _ opencdc.Position) error {
-			is.Equal(wantContextName, sdkSchema.GetSchemaContextName(ctx))
+			is.Equal(wantContextName, sdkschema.GetSchemaContextName(ctx))
 			return nil
 		})
 

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -182,9 +182,6 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 	src := NewMockSource(ctrl)
 	ctx := context.Background()
 
-	connectorID := uuid.NewString()
-	ctx = internal.Enrich(ctx, pconnector.PluginConfig{ConnectorID: connectorID})
-
 	s := (&SourceWithSchemaExtraction{}).Wrap(src)
 
 	src.EXPECT().Configure(ctx, gomock.Any()).Return(nil)


### PR DESCRIPTION
### Description

This PR adds `DestinationWithSchemaExtraction` middleware, which is the counterpart to `SourceWithSchemaExtraction` introduced in https://github.com/ConduitIO/conduit-connector-sdk/pull/152. It checks the record metadata for an attached schema subject and version, fetches the schema and decodes the raw payload into a structured one using the obtained schema.

A few additional changes:
- Functions `DestinationWithMiddleware` and `SourceWithMiddleware` now apply middleware in the reverse order, so the order of calls between the middleware is in the same order as supplied by the caller.
- Parameters that end with `*.enable` changed to `*.enabled`.
- Rename a few tests.

Fixes #138

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
