### PR TITLE
Add note about params used when parsing configs

### DIFF
--- a/util.go
+++ b/util.go
@@ -34,6 +34,10 @@ var Util = struct {
 	// convenient function. It is intended to be used in the Configure method of a
 	// connector to parse the configuration map.
 	//
+	// The configuration parameters should be provided through NewSource().Parameters()
+	// or NewDestination().Parameters() so that parameters from SDK middlewares are
+	// included too.
+	//
 	// The function does the following:
 	//   - Removes leading and trailing spaces from all keys and values in the
 	//     configuration.


### PR DESCRIPTION
### Description

When parsing configs using `sdk.Util.ParseConfig`, the configuration parameters used need to be provided through `NewSource()`/`NewDestination()` so that they include the SDK middleware parameters too.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
