### PR TITLE
Generate IDs in in-memory schema service

### DIFF
--- a/schema/in_memory.go
+++ b/schema/in_memory.go
@@ -29,6 +29,8 @@ type inMemoryService struct {
 	schemas map[string][]schema.Schema
 	// m guards access to schemas
 	m sync.Mutex
+	// idSequence is used to generate unique schema IDs
+	idSequence int
 }
 
 func newInMemoryService() pconnutils.SchemaService {
@@ -46,6 +48,7 @@ func (s *inMemoryService) CreateSchema(_ context.Context, request pconnutils.Cre
 	defer s.m.Unlock()
 
 	inst := schema.Schema{
+		ID:      s.nextID(),
 		Subject: request.Subject,
 		Version: len(s.schemas[request.Subject]) + 1,
 		Type:    request.Type,
@@ -70,4 +73,9 @@ func (s *inMemoryService) GetSchema(_ context.Context, request pconnutils.GetSch
 	}
 
 	return pconnutils.GetSchemaResponse{Schema: versions[request.Version-1]}, nil
+}
+
+func (s *inMemoryService) nextID() int {
+	s.idSequence++
+	return s.idSequence
 }

--- a/schema/in_memory_test.go
+++ b/schema/in_memory_test.go
@@ -28,6 +28,7 @@ func TestInMemoryService(t *testing.T) {
 	ctx := context.Background()
 
 	want1 := schema.Schema{
+		ID:      1,
 		Subject: "test-subject",
 		Version: 1,
 		Type:    schema.TypeAvro,
@@ -41,6 +42,7 @@ func TestInMemoryService(t *testing.T) {
 
 	// Create second version
 	want2 := schema.Schema{
+		ID:      2,
 		Subject: want1.Subject,
 		Version: 2,
 		Type:    want1.Type,


### PR DESCRIPTION
### Description

We added IDs to schemas in a later change and forgot to update the in-memory schema service to generate IDs.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
