### PR TITLE
Set log level in connectors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,6 @@ Fixes # (issue)
 ### Quick checks:
 
 - [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
-- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
-  update/change.
+- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
 - [ ] I have written unit tests.
 - [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.

--- a/logger.go
+++ b/logger.go
@@ -30,7 +30,7 @@ func Logger(ctx context.Context) *zerolog.Logger {
 
 // initStandaloneModeLogger will create a default context logger that can be
 // used by the plugin in standalone mode. Should not be called in builtin mode.
-func initStandaloneModeLogger() {
+func initStandaloneModeLogger(level zerolog.Level) {
 	// adjust field names to have parity with hclog, go-plugin uses hclog to
 	// parse log messages
 	zerolog.LevelFieldName = "@level"
@@ -39,6 +39,7 @@ func initStandaloneModeLogger() {
 	zerolog.MessageFieldName = "@message"
 
 	logger := zerolog.New(os.Stderr)
+	logger = logger.Level(level)
 
 	zerolog.DefaultContextLogger = &logger
 }

--- a/serve.go
+++ b/serve.go
@@ -115,16 +115,15 @@ func connectorUtilitiesGRPCTarget() (string, error) {
 
 // connectorLogLevel returns the log level to be used by the connector. The value
 // is fetched from the environment variable provided by conduit-connector-protocol.
-// The function returns 0 if the environment variable is not specified or empty.
+// The function returns the TRACE level if the environment variable is not
+// specified or empty (that's the zerolog default).
 func connectorLogLevel() zerolog.Level {
 	level := os.Getenv(pconnutils.EnvConduitLogLevel)
-	if level == "" {
-		return 0
-	}
 
 	l, err := zerolog.ParseLevel(level)
 	if err != nil {
-		return 0
+		// Default to TRACE, logs will get filtered by Conduit.
+		return zerolog.TraceLevel
 	}
 
 	return l

--- a/serve.go
+++ b/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/pconnector/server"
 	"github.com/conduitio/conduit-connector-protocol/pconnutils"
 	"github.com/conduitio/conduit-connector-sdk/internal"
+	"github.com/rs/zerolog"
 )
 
 // Serve starts the plugin and takes care of its whole lifecycle by blocking
@@ -44,7 +45,7 @@ func Serve(c Connector) {
 }
 
 func serve(c Connector) error {
-	initStandaloneModeLogger()
+	initStandaloneModeLogger(connectorLogLevel())
 
 	target, err := connectorUtilitiesGRPCTarget()
 	if err != nil {
@@ -110,6 +111,23 @@ func connectorUtilitiesGRPCTarget() (string, error) {
 	}
 
 	return target, nil
+}
+
+// connectorLogLevel returns the log level to be used by the connector. The value
+// is fetched from the environment variable provided by conduit-connector-protocol.
+// The function returns 0 if the environment variable is not specified or empty.
+func connectorLogLevel() zerolog.Level {
+	level := os.Getenv(pconnutils.EnvConduitLogLevel)
+	if level == "" {
+		return 0
+	}
+
+	l, err := zerolog.ParseLevel(level)
+	if err != nil {
+		return 0
+	}
+
+	return l
 }
 
 func missingEnvError(envVar, conduitVersion string) error {


### PR DESCRIPTION
### Description

Try to get the log level from an env variable and apply it to the standalone logger.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same
  update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
