### PR TITLE
Assign source and dst params to spec

### DIFF
--- a/specifier.go
+++ b/specifier.go
@@ -51,7 +51,12 @@ type specifierPluginAdapter struct {
 }
 
 func (s *specifierPluginAdapter) Specify(context.Context, pconnector.SpecifierSpecifyRequest) (pconnector.SpecifierSpecifyResponse, error) {
-	return pconnector.SpecifierSpecifyResponse{
+	resp := pconnector.SpecifierSpecifyResponse{
 		Specification: pconnector.Specification(s.specs),
-	}, nil
+	}
+
+	resp.Specification.SourceParams = s.sourceParams
+	resp.Specification.DestinationParams = s.destinationParams
+
+	return resp, nil
 }

--- a/specifier_test.go
+++ b/specifier_test.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
+	"github.com/google/go-cmp/cmp"
 	"github.com/matryer/is"
 )
 
@@ -36,4 +38,126 @@ func TestSpecifier_NilDestination(t *testing.T) {
 	p := NewSpecifierPlugin(Specification{}, UnimplementedSource{}, nil)
 	_, err := p.Specify(context.Background(), pconnector.SpecifierSpecifyRequest{})
 	is.NoErr(err)
+}
+
+func TestSpecifier_Connector(t *testing.T) {
+	is := is.New(t)
+
+	c := Connector{
+		NewSpecification: testConnSpec,
+		NewSource:        newTestSpecSource,
+		NewDestination:   newTestSpecDestination,
+	}
+
+	s := NewSpecifierPlugin(c.NewSpecification(), c.NewSource(), c.NewDestination())
+	got, err := s.Specify(context.Background(), pconnector.SpecifierSpecifyRequest{})
+
+	want := pconnector.SpecifierSpecifyResponse{
+		Specification: pconnector.Specification{
+			Name:        "testSpecConn",
+			Summary:     "summary of spec conn",
+			Description: "desc of spec conn",
+			Version:     "(devel+1)",
+			Author:      "sdk-max",
+			SourceParams: map[string]config.Parameter{
+				"srcParam1": {
+					Default:     "",
+					Description: "source param 1",
+					Type:        config.ParameterTypeString,
+					Validations: []config.Validation{
+						config.ValidationRequired{},
+					},
+				},
+				"srcParam2": {
+					Default:     "set",
+					Description: "source param 2",
+					Type:        config.ParameterTypeString,
+					Validations: []config.Validation{},
+				},
+			},
+			DestinationParams: map[string]config.Parameter{
+				"destParam1": {
+					Default:     "",
+					Description: "dest param 1",
+					Type:        config.ParameterTypeString,
+					Validations: []config.Validation{
+						config.ValidationRequired{},
+					},
+				},
+				"destParam2": {
+					Default:     "unset",
+					Description: "dest param 2",
+					Type:        config.ParameterTypeString,
+					Validations: []config.Validation{},
+				},
+			},
+		},
+	}
+
+	is.NoErr(err)
+	is.Equal("", cmp.Diff(want, got))
+}
+
+func testConnSpec() Specification {
+	return Specification{
+		Name:        "testSpecConn",
+		Summary:     "summary of spec conn",
+		Description: "desc of spec conn",
+		Version:     "(devel+1)",
+		Author:      "sdk-max",
+	}
+}
+
+type testSpecSource struct {
+	UnimplementedSource
+}
+
+func newTestSpecSource() Source {
+	return &testSpecSource{}
+}
+
+func (s *testSpecSource) Parameters() config.Parameters {
+	return map[string]config.Parameter{
+		"srcParam1": {
+			Default:     "",
+			Description: "source param 1",
+			Type:        config.ParameterTypeString,
+			Validations: []config.Validation{
+				config.ValidationRequired{},
+			},
+		},
+		"srcParam2": {
+			Default:     "set",
+			Description: "source param 2",
+			Type:        config.ParameterTypeString,
+			Validations: []config.Validation{},
+		},
+	}
+}
+
+type testSpecDestination struct {
+	UnimplementedDestination
+}
+
+func newTestSpecDestination() Destination {
+	return &testSpecDestination{}
+}
+
+func (d *testSpecDestination) Parameters() config.Parameters {
+	return map[string]config.Parameter{
+		"destParam1": {
+			Default:     "",
+			Description: "dest param 1",
+			Type:        config.ParameterTypeString,
+			Validations: []config.Validation{
+				config.ValidationRequired{},
+			},
+		},
+		"destParam2": {
+			Default:     "unset",
+			Description: "dest param 2",
+			Type:        config.ParameterTypeString,
+			Validations: []config.Validation{},
+		},
+	}
 }


### PR DESCRIPTION
### Description

Specification was coming empty when plugins were described.
Looks like params were not assigned to the spec when it was created.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
