### PR TITLE
Add aliases for types in schema package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,7 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - copyloopvar
     - decorder
     # - depguard
     - dogsled
@@ -72,7 +73,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     # - forbidigo
     - forcetypeassert
     # - funlen

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
-	sdkschema "github.com/conduitio/conduit-connector-sdk/schema"
+	"github.com/conduitio/conduit-connector-sdk/schema"
 	"golang.org/x/time/rate"
 )
 
@@ -759,7 +759,7 @@ func (d *destinationWithSchemaExtraction) decode(ctx context.Context, data openc
 		return nil, fmt.Errorf("unexpected data type %T", data)
 	}
 
-	sch, err := sdkschema.Get(ctx, subject, version)
+	sch, err := schema.Get(ctx, subject, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema for %s:%d: %w", subject, version, err)
 	}

--- a/destination_middleware_test.go
+++ b/destination_middleware_test.go
@@ -24,11 +24,10 @@ import (
 
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
-	"github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-commons/schema/avro"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit-connector-sdk/internal"
-	sdkschema "github.com/conduitio/conduit-connector-sdk/schema"
+	"github.com/conduitio/conduit-connector-sdk/schema"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
 	"go.uber.org/mock/gomock"
@@ -480,7 +479,7 @@ func TestDestinationWithSchemaExtraction_Write(t *testing.T) {
 
 	srd, err := avro.SerdeForType(testStructuredData)
 	is.NoErr(err)
-	sch, err := sdkschema.Create(ctx, schema.TypeAvro, "TestDestinationWithSchemaExtraction_Write", []byte(srd.String()))
+	sch, err := schema.Create(ctx, schema.TypeAvro, "TestDestinationWithSchemaExtraction_Write", []byte(srd.String()))
 	is.NoErr(err)
 
 	b, err := sch.Marshal(testStructuredData)

--- a/schema/cached.go
+++ b/schema/cached.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-connector-protocol/pconnutils"
 	"github.com/twmb/go-cache/cache"
 )
@@ -45,7 +44,7 @@ type cachedSchemaService struct {
 
 type comparableCreateSchemaRequest struct {
 	Subject string
-	Type    schema.Type
+	Type    Type
 	Bytes   string
 }
 

--- a/schema/cached_test.go
+++ b/schema/cached_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-connector-protocol/pconnutils"
 	"github.com/conduitio/conduit-connector-protocol/pconnutils/mock"
 	"github.com/matryer/is"
@@ -36,11 +35,11 @@ func TestCachedSchemaService_Get(t *testing.T) {
 		Version: 1,
 	}
 	resp1 := pconnutils.GetSchemaResponse{
-		Schema: schema.Schema{
+		Schema: Schema{
 			ID:      1,
 			Subject: "test",
 			Version: 1,
-			Type:    schema.TypeAvro,
+			Type:    TypeAvro,
 			Bytes:   []byte("int"),
 		},
 	}
@@ -50,11 +49,11 @@ func TestCachedSchemaService_Get(t *testing.T) {
 		Version: 2,
 	}
 	resp2 := pconnutils.GetSchemaResponse{
-		Schema: schema.Schema{
+		Schema: Schema{
 			ID:      2,
 			Subject: "test",
 			Version: 2,
-			Type:    schema.TypeAvro,
+			Type:    TypeAvro,
 			Bytes:   []byte("string"),
 		},
 	}
@@ -84,30 +83,30 @@ func TestCachedSchemaService_Create(t *testing.T) {
 
 	req1 := pconnutils.CreateSchemaRequest{
 		Subject: "test",
-		Type:    schema.TypeAvro,
+		Type:    TypeAvro,
 		Bytes:   []byte("int"),
 	}
 	resp1 := pconnutils.CreateSchemaResponse{
-		Schema: schema.Schema{
+		Schema: Schema{
 			ID:      1,
 			Subject: "test",
 			Version: 1,
-			Type:    schema.TypeAvro,
+			Type:    TypeAvro,
 			Bytes:   []byte("int"),
 		},
 	}
 
 	req2 := pconnutils.CreateSchemaRequest{
 		Subject: "test",
-		Type:    schema.TypeAvro,
+		Type:    TypeAvro,
 		Bytes:   []byte("string"),
 	}
 	resp2 := pconnutils.CreateSchemaResponse{
-		Schema: schema.Schema{
+		Schema: Schema{
 			ID:      2,
 			Subject: "test",
 			Version: 2,
-			Type:    schema.TypeAvro,
+			Type:    TypeAvro,
 			Bytes:   []byte("string"),
 		},
 	}

--- a/schema/commons.go
+++ b/schema/commons.go
@@ -1,0 +1,48 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-commons/schema"
+)
+
+// This file contains type aliases for the conduit-commons/schema package. This
+// makes it easier to use the schema package in other packages without having to
+// import conduit-commons/schema directly.
+
+// Type aliases for schema package.
+type (
+	// Type represents the type of a schema (avro, protobuf, etc).
+	Type = schema.Type
+	// Schema represents a schema object.
+	Schema = schema.Schema
+	// Serde represents a serializer/deserializer.
+	Serde = schema.Serde
+)
+
+const (
+	TypeAvro = schema.TypeAvro
+)
+
+var KnownSerdeFactories = schema.KnownSerdeFactories
+
+func AttachKeySchemaToRecord(r opencdc.Record, s Schema) {
+	schema.AttachKeySchemaToRecord(r, s)
+}
+
+func AttachPayloadSchemaToRecord(r opencdc.Record, s Schema) {
+	schema.AttachPayloadSchemaToRecord(r, s)
+}

--- a/schema/in_memory.go
+++ b/schema/in_memory.go
@@ -19,14 +19,13 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-connector-protocol/pconnutils"
 )
 
 type inMemoryService struct {
 	// schemas is a map of schema subjects to all the versions of that schema
 	// versioning starts at 1, newer versions are appended to the end of the versions slice.
-	schemas map[string][]schema.Schema
+	schemas map[string][]Schema
 	// m guards access to schemas
 	m sync.Mutex
 	// idSequence is used to generate unique schema IDs
@@ -35,19 +34,19 @@ type inMemoryService struct {
 
 func newInMemoryService() pconnutils.SchemaService {
 	return &inMemoryService{
-		schemas: make(map[string][]schema.Schema),
+		schemas: make(map[string][]Schema),
 	}
 }
 
 func (s *inMemoryService) CreateSchema(_ context.Context, request pconnutils.CreateSchemaRequest) (pconnutils.CreateSchemaResponse, error) {
-	if request.Type != schema.TypeAvro {
+	if request.Type != TypeAvro {
 		return pconnutils.CreateSchemaResponse{}, fmt.Errorf("unsupported schema type: %s", request.Type)
 	}
 
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	inst := schema.Schema{
+	inst := Schema{
 		ID:      s.nextID(),
 		Subject: request.Subject,
 		Version: len(s.schemas[request.Subject]) + 1,

--- a/schema/in_memory_test.go
+++ b/schema/in_memory_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/conduitio/conduit-commons/schema"
 	"github.com/google/go-cmp/cmp"
 	"github.com/matryer/is"
 )
@@ -27,11 +26,11 @@ func TestInMemoryService(t *testing.T) {
 	is := is.New(t)
 	ctx := context.Background()
 
-	want1 := schema.Schema{
+	want1 := Schema{
 		ID:      1,
 		Subject: "test-subject",
 		Version: 1,
-		Type:    schema.TypeAvro,
+		Type:    TypeAvro,
 		Bytes:   []byte("irrelevant 1"),
 	}
 
@@ -41,7 +40,7 @@ func TestInMemoryService(t *testing.T) {
 	is.Equal("", cmp.Diff(want1, created1))
 
 	// Create second version
-	want2 := schema.Schema{
+	want2 := Schema{
 		ID:      2,
 		Subject: want1.Subject,
 		Version: 2,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -33,6 +33,8 @@ var (
 	ErrSubjectNotFound = pconnutils.ErrSubjectNotFound
 	ErrVersionNotFound = pconnutils.ErrVersionNotFound
 	ErrInvalidSchema   = pconnutils.ErrInvalidSchema
+
+	ErrUnsupportedType = schema.ErrUnsupportedType
 )
 
 // Service is the schema service client that can be used to interact with the schema service.
@@ -40,14 +42,14 @@ var (
 var Service pconnutils.SchemaService = newCachedSchemaService(newInMemoryService())
 
 // Create creates a new schema with the given name and bytes. The schema type must be Avro.
-func Create(ctx context.Context, typ schema.Type, subject string, bytes []byte) (schema.Schema, error) {
+func Create(ctx context.Context, typ Type, subject string, bytes []byte) (Schema, error) {
 	resp, err := Service.CreateSchema(ctx, pconnutils.CreateSchemaRequest{
 		Subject: qualifiedSubject(ctx, subject),
 		Type:    typ,
 		Bytes:   bytes,
 	})
 	if err != nil {
-		return schema.Schema{}, err
+		return Schema{}, err
 	}
 
 	return resp.Schema, nil
@@ -66,13 +68,13 @@ func qualifiedSubject(ctx context.Context, subject string) string {
 }
 
 // Get retrieves the schema with the given name and version. If the schema does not exist, an error is returned.
-func Get(ctx context.Context, subject string, version int) (schema.Schema, error) {
+func Get(ctx context.Context, subject string, version int) (Schema, error) {
 	resp, err := Service.GetSchema(ctx, pconnutils.GetSchemaRequest{
 		Subject: subject,
 		Version: version,
 	})
 	if err != nil {
-		return schema.Schema{}, err
+		return Schema{}, err
 	}
 
 	return resp.Schema, nil

--- a/source_middleware.go
+++ b/source_middleware.go
@@ -23,9 +23,8 @@ import (
 
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
-	"github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-connector-sdk/internal"
-	sdkschema "github.com/conduitio/conduit-connector-sdk/schema"
+	"github.com/conduitio/conduit-connector-sdk/schema"
 )
 
 // SourceMiddleware wraps a Source and adds functionality to it.
@@ -327,7 +326,7 @@ func (s *sourceWithSchemaExtraction) schemaForKey(ctx context.Context, rec openc
 	case subject != "" && version > 0:
 		// The connector has attached the schema subject and version, we can use
 		// it to retrieve the schema from the schema service.
-		return sdkschema.Get(ctx, subject, version)
+		return schema.Get(ctx, subject, version)
 	case subject != "" || version > 0:
 		// The connector has attached either the schema subject or version, but
 		// not both, this isn't valid.
@@ -405,7 +404,7 @@ func (s *sourceWithSchemaExtraction) schemaForPayload(ctx context.Context, rec o
 	case subject != "" && version > 0:
 		// The connector has attached the schema subject and version, we can use
 		// it to retrieve the schema from the schema service.
-		return sdkschema.Get(ctx, subject, version)
+		return schema.Get(ctx, subject, version)
 	case subject != "" || version > 0:
 		// The connector has attached either the schema subject or version, but
 		// not both, this isn't valid.
@@ -438,7 +437,7 @@ func (s *sourceWithSchemaExtraction) schemaForType(ctx context.Context, data any
 		return schema.Schema{}, fmt.Errorf("failed to create schema for value: %w", err)
 	}
 
-	sch, err := sdkschema.Create(ctx, s.schemaType, subject, []byte(srd.String()))
+	sch, err := schema.Create(ctx, s.schemaType, subject, []byte(srd.String()))
 	if err != nil {
 		return schema.Schema{}, fmt.Errorf("failed to create schema: %w", err)
 	}
@@ -572,31 +571,31 @@ func (s *sourceWithSchemaContext) Configure(ctx context.Context, cfg config.Conf
 		}
 	}
 
-	return s.Source.Configure(sdkschema.WithSchemaContextName(ctx, s.contextName), cfg)
+	return s.Source.Configure(schema.WithSchemaContextName(ctx, s.contextName), cfg)
 }
 
 func (s *sourceWithSchemaContext) Open(ctx context.Context, pos opencdc.Position) error {
-	return s.Source.Open(sdkschema.WithSchemaContextName(ctx, s.contextName), pos)
+	return s.Source.Open(schema.WithSchemaContextName(ctx, s.contextName), pos)
 }
 
 func (s *sourceWithSchemaContext) Read(ctx context.Context) (opencdc.Record, error) {
-	return s.Source.Read(sdkschema.WithSchemaContextName(ctx, s.contextName))
+	return s.Source.Read(schema.WithSchemaContextName(ctx, s.contextName))
 }
 
 func (s *sourceWithSchemaContext) Teardown(ctx context.Context) error {
-	return s.Source.Teardown(sdkschema.WithSchemaContextName(ctx, s.contextName))
+	return s.Source.Teardown(schema.WithSchemaContextName(ctx, s.contextName))
 }
 
 func (s *sourceWithSchemaContext) LifecycleOnCreated(ctx context.Context, config config.Config) error {
-	return s.Source.LifecycleOnCreated(sdkschema.WithSchemaContextName(ctx, s.contextName), config)
+	return s.Source.LifecycleOnCreated(schema.WithSchemaContextName(ctx, s.contextName), config)
 }
 
 func (s *sourceWithSchemaContext) LifecycleOnUpdated(ctx context.Context, configBefore, configAfter config.Config) error {
-	return s.Source.LifecycleOnUpdated(sdkschema.WithSchemaContextName(ctx, s.contextName), configBefore, configAfter)
+	return s.Source.LifecycleOnUpdated(schema.WithSchemaContextName(ctx, s.contextName), configBefore, configAfter)
 }
 
 func (s *sourceWithSchemaContext) LifecycleOnDeleted(ctx context.Context, config config.Config) error {
-	return s.Source.LifecycleOnDeleted(sdkschema.WithSchemaContextName(ctx, s.contextName), config)
+	return s.Source.LifecycleOnDeleted(schema.WithSchemaContextName(ctx, s.contextName), config)
 }
 
 func ptr[T any](t T) *T {

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -24,10 +24,9 @@ import (
 
 	"github.com/conduitio/conduit-commons/config"
 	"github.com/conduitio/conduit-commons/opencdc"
-	"github.com/conduitio/conduit-commons/schema"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit-connector-sdk/internal"
-	sdkschema "github.com/conduitio/conduit-connector-sdk/schema"
+	"github.com/conduitio/conduit-connector-sdk/schema"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/matryer/is"
@@ -197,7 +196,7 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 	}
 	wantSchema := `{"name":"record","type":"record","fields":[{"name":"float","type":"double"},{"name":"foo","type":"string"},{"name":"long","type":"long"},{"name":"time","type":{"type":"long","logicalType":"timestamp-micros"}}]}`
 
-	customTestSchema, err := sdkschema.Create(ctx, schema.TypeAvro, "custom-test-schema", []byte(wantSchema))
+	customTestSchema, err := schema.Create(ctx, schema.TypeAvro, "custom-test-schema", []byte(wantSchema))
 	is.NoErr(err)
 
 	testCases := []struct {
@@ -390,7 +389,7 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				is.Equal(subject, tc.wantKeySubject)
 				is.Equal(version, 1)
 
-				sch, err := sdkschema.Get(ctx, subject, version)
+				sch, err := schema.Get(ctx, subject, version)
 				is.NoErr(err)
 
 				is.Equal("", cmp.Diff(wantSchema, string(sch.Bytes)))
@@ -418,7 +417,7 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				is.Equal(subject, tc.wantPayloadSubject)
 				is.Equal(version, 1)
 
-				sch, err := sdkschema.Get(ctx, subject, version)
+				sch, err := schema.Get(ctx, subject, version)
 				is.NoErr(err)
 
 				is.Equal("", cmp.Diff(wantSchema, string(sch.Bytes)))
@@ -612,7 +611,7 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 			s.EXPECT().
 				Configure(gomock.Any(), tc.connectorCfg).
 				DoAndReturn(func(ctx context.Context, c config.Config) error {
-					gotContextName := sdkschema.GetSchemaContextName(ctx)
+					gotContextName := schema.GetSchemaContextName(ctx)
 					is.Equal(tc.wantContextName, gotContextName)
 					return nil
 				})
@@ -639,13 +638,13 @@ func TestSourceWithSchemaContext_ContextValue(t *testing.T) {
 	s.EXPECT().
 		Configure(gomock.Any(), connectorCfg).
 		DoAndReturn(func(ctx context.Context, _ config.Config) error {
-			is.Equal(wantContextName, sdkschema.GetSchemaContextName(ctx))
+			is.Equal(wantContextName, schema.GetSchemaContextName(ctx))
 			return nil
 		})
 	s.EXPECT().
 		Open(gomock.Any(), opencdc.Position{}).
 		DoAndReturn(func(ctx context.Context, _ opencdc.Position) error {
-			is.Equal(wantContextName, sdkschema.GetSchemaContextName(ctx))
+			is.Equal(wantContextName, schema.GetSchemaContextName(ctx))
 			return nil
 		})
 


### PR DESCRIPTION
### Description

This should make it easier to use the `schema` package, since you have everything there and don't need to import `conduit-commons/schema` directly.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
