### PR TITLE
End-to-end batching

### DIFF
--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit-commons/config"
+	"github.com/conduitio/conduit-commons/lang"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-connector-sdk/schema"
 	"golang.org/x/time/rate"
@@ -186,6 +187,11 @@ func (d *destinationWithBatch) Configure(ctx context.Context, config config.Conf
 	if cfg.BatchDelay < 0 {
 		return fmt.Errorf("invalid %q: must not be negative", configDestinationBatchDelay)
 	}
+
+	// TODO: emit this warning once we move to source batching
+	// if cfg.BatchDelay > 0 || cfg.BatchSize > 0 {
+	// 	Logger(ctx).Warn().Msg("Batching in the destination is deprecated. Consider moving the `sdk.batch.size` and `sdk.batch.delay` parameters to the source connector to enable batching at the source.")
+	// }
 
 	// Batching is actually implemented in the plugin adapter because it is the
 	// only place we have access to acknowledgments.
@@ -610,10 +616,10 @@ type DestinationWithSchemaExtraction struct {
 // values if they are not explicitly set.
 func (s *DestinationWithSchemaExtraction) Wrap(impl Destination) Destination {
 	if s.Config.KeyEnabled == nil {
-		s.Config.KeyEnabled = ptr(true)
+		s.Config.KeyEnabled = lang.Ptr(true)
 	}
 	if s.Config.PayloadEnabled == nil {
-		s.Config.PayloadEnabled = ptr(true)
+		s.Config.PayloadEnabled = lang.Ptr(true)
 	}
 	return &destinationWithSchemaExtraction{
 		Destination: impl,

--- a/destination_middleware_test.go
+++ b/destination_middleware_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit-commons/config"
+	"github.com/conduitio/conduit-commons/lang"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-commons/schema/avro"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
@@ -359,8 +360,8 @@ func TestDestinationWithSchemaExtractionConfig_Apply(t *testing.T) {
 	is := is.New(t)
 
 	wantCfg := DestinationWithSchemaExtractionConfig{
-		PayloadEnabled: ptr(true),
-		KeyEnabled:     ptr(true),
+		PayloadEnabled: lang.Ptr(true),
+		KeyEnabled:     lang.Ptr(true),
 	}
 
 	have := &DestinationWithSchemaExtraction{}
@@ -417,8 +418,8 @@ func TestDestinationWithSchemaExtraction_Configure(t *testing.T) {
 		name: "disabled by default",
 		middleware: DestinationWithSchemaExtraction{
 			Config: DestinationWithSchemaExtractionConfig{
-				PayloadEnabled: ptr(false),
-				KeyEnabled:     ptr(false),
+				PayloadEnabled: lang.Ptr(false),
+				KeyEnabled:     lang.Ptr(false),
 			},
 		},
 		have: config.Config{},

--- a/destination_test.go
+++ b/destination_test.go
@@ -220,16 +220,18 @@ func TestDestinationPluginAdapter_Run_WriteBatch_Success(t *testing.T) {
 		err = clientStream.Send(pconnector.DestinationRunRequest{Records: []opencdc.Record{want}})
 		is.NoErr(err)
 	}
-	for i := 0; i < 5; i++ {
-		resp, err := clientStream.Recv()
-		is.NoErr(err)
-		is.Equal(resp, pconnector.DestinationRunResponse{
-			Acks: []pconnector.DestinationRunResponseAck{{
-				Position: want.Position,
-				Error:    "",
-			}},
-		})
-	}
+
+	resp, err := clientStream.Recv()
+	is.NoErr(err)
+	is.Equal(resp, pconnector.DestinationRunResponse{
+		Acks: []pconnector.DestinationRunResponseAck{
+			{Position: want.Position, Error: ""},
+			{Position: want.Position, Error: ""},
+			{Position: want.Position, Error: ""},
+			{Position: want.Position, Error: ""},
+			{Position: want.Position, Error: ""},
+		},
+	})
 
 	// close stream
 	stream.Close(io.EOF)
@@ -293,26 +295,25 @@ func TestDestinationPluginAdapter_Run_WriteBatch_Partial(t *testing.T) {
 		err = clientStream.Send(pconnector.DestinationRunRequest{Records: []opencdc.Record{want}})
 		is.NoErr(err)
 	}
-	for i := 0; i < 3; i++ {
-		resp, err := clientStream.Recv()
-		is.NoErr(err)
-		is.Equal(resp, pconnector.DestinationRunResponse{
-			Acks: []pconnector.DestinationRunResponseAck{{
-				Position: want.Position,
-				Error:    "",
-			}},
-		})
-	}
-	for i := 0; i < 2; i++ {
-		resp, err := clientStream.Recv()
-		is.NoErr(err)
-		is.Equal(resp, pconnector.DestinationRunResponse{
-			Acks: []pconnector.DestinationRunResponseAck{{
-				Position: want.Position,
-				Error:    wantErr.Error(),
-			}},
-		})
-	}
+
+	resp, err := clientStream.Recv()
+	is.NoErr(err)
+	is.Equal(resp, pconnector.DestinationRunResponse{
+		Acks: []pconnector.DestinationRunResponseAck{
+			{Position: want.Position, Error: ""},
+			{Position: want.Position, Error: ""},
+			{Position: want.Position, Error: ""},
+		},
+	})
+
+	resp, err = clientStream.Recv()
+	is.NoErr(err)
+	is.Equal(resp, pconnector.DestinationRunResponse{
+		Acks: []pconnector.DestinationRunResponseAck{
+			{Position: want.Position, Error: wantErr.Error()},
+			{Position: want.Position, Error: wantErr.Error()},
+		},
+	})
 
 	// close stream
 	stream.Close(io.EOF)

--- a/mock_source_test.go
+++ b/mock_source_test.go
@@ -343,6 +343,45 @@ func (c *MockSourceReadCall) DoAndReturn(f func(context.Context) (opencdc.Record
 	return c
 }
 
+// ReadBatch mocks base method.
+func (m *MockSource) ReadBatch(arg0 context.Context) ([]opencdc.Record, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadBatch", arg0)
+	ret0, _ := ret[0].([]opencdc.Record)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadBatch indicates an expected call of ReadBatch.
+func (mr *MockSourceMockRecorder) ReadBatch(arg0 any) *MockSourceReadBatchCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadBatch", reflect.TypeOf((*MockSource)(nil).ReadBatch), arg0)
+	return &MockSourceReadBatchCall{Call: call}
+}
+
+// MockSourceReadBatchCall wrap *gomock.Call
+type MockSourceReadBatchCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockSourceReadBatchCall) Return(arg0 []opencdc.Record, arg1 error) *MockSourceReadBatchCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockSourceReadBatchCall) Do(f func(context.Context) ([]opencdc.Record, error)) *MockSourceReadBatchCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockSourceReadBatchCall) DoAndReturn(f func(context.Context) ([]opencdc.Record, error)) *MockSourceReadBatchCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Teardown mocks base method.
 func (m *MockSource) Teardown(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/source.go
+++ b/source.go
@@ -42,6 +42,8 @@ var (
 
 // Source fetches records from 3rd party resources and sends them to Conduit.
 // All implementations must embed UnimplementedSource for forward compatibility.
+//
+//nolint:interfacebloat // Source interface is a contract and should not be split
 type Source interface {
 	// Parameters is a map of named Parameters that describe how to configure
 	// the Source.
@@ -82,6 +84,12 @@ type Source interface {
 	// the error is ErrBackoffRetry, as mentioned above).
 	// Read can be called concurrently with Ack.
 	Read(context.Context) (opencdc.Record, error)
+
+	// ReadBatch is the same as Read, but returns a batch of records. The
+	// default implementation calls Read and returns the single record in a
+	// batch.
+	ReadBatch(context.Context) ([]opencdc.Record, error)
+
 	// Ack signals to the implementation that the record with the supplied
 	// position was successfully processed. This method might be called after
 	// the context of Read is already cancelled, since there might be
@@ -245,18 +253,14 @@ func (a *sourcePluginAdapter) runRead(ctx context.Context, stream pconnector.Sou
 		Max:    time.Second * 5,
 	}
 
-	batchSize := 10000
-	batch := make([]opencdc.Record, 0, batchSize)
-
-	logger := Logger(ctx)
+	batching := true
+	readFn := a.impl.ReadBatch
 
 	for {
-		r, err := a.impl.Read(ctx)
+		recs, err := readFn(ctx)
 		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				return nil // not an actual error
-			}
-			if errors.Is(err, ErrBackoffRetry) {
+			switch {
+			case errors.Is(err, ErrBackoffRetry):
 				// the plugin wants us to retry reading later
 				_, _, err := cchan.ChanOut[time.Time](time.After(b.Duration())).Recv(ctx)
 				if err != nil {
@@ -265,26 +269,41 @@ func (a *sourcePluginAdapter) runRead(ctx context.Context, stream pconnector.Sou
 					return nil
 				}
 				continue
+
+			case errors.Is(err, context.Canceled):
+				return nil // not an actual error
+
+			case errors.Is(err, ErrUnimplemented) && batching:
+				Logger(ctx).Info().Msg("source does not support batch reads, falling back to single reads")
+
+				// the plugin doesn't support batch reads, fallback to single reads
+				readFn = func(ctx context.Context) ([]opencdc.Record, error) {
+					rec, err := a.impl.Read(ctx)
+					if err != nil {
+						return nil, err
+					}
+					return []opencdc.Record{rec}, nil
+				}
+				batching = false
+				continue
+
+			default:
+				return fmt.Errorf("read plugin error: %w", err)
 			}
-			return fmt.Errorf("read plugin error: %w", err)
 		}
 
-		batch = append(batch, r)
-		if len(batch) < batchSize {
+		if len(recs) == 0 {
 			continue
 		}
 
-		logger.Debug().Msg("flushing batch")
-		err = stream.Send(pconnector.SourceRunResponse{Records: batch})
-		logger.Debug().Msg("sent!")
+		err = stream.Send(pconnector.SourceRunResponse{Records: recs})
 		if err != nil {
 			return fmt.Errorf("read stream error: %w", err)
 		}
-		a.lastPosition = r.Position // store last sent position
+		a.lastPosition = recs[len(recs)-1].Position // store last sent position
 
 		// reset backoff retry
 		b.Reset()
-		batch = make([]opencdc.Record, 0, batchSize)
 	}
 }
 
@@ -337,6 +356,7 @@ func (a *sourcePluginAdapter) Stop(ctx context.Context, _ pconnector.SourceStopR
 		return pconnector.SourceStopResponse{}, fmt.Errorf("failed to stop connector: %w", err)
 	}
 
+	Logger(ctx).Debug().Msg("waiting for Read to stop running ...")
 	// wait for read to actually stop running with a timeout, in case the
 	// connector gets stuck
 	_, _, err = cchan.ChanOut[struct{}](a.readDone).Recv(ctx)
@@ -345,6 +365,7 @@ func (a *sourcePluginAdapter) Stop(ctx context.Context, _ pconnector.SourceStopR
 		return pconnector.SourceStopResponse{}, fmt.Errorf("failed to stop connector: %w", err)
 	}
 
+	Logger(ctx).Debug().Msg("stop successful")
 	return pconnector.SourceStopResponse{
 		LastPosition: a.lastPosition,
 	}, nil

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/conduitio/conduit-commons/config"
+	"github.com/conduitio/conduit-commons/lang"
 	"github.com/conduitio/conduit-commons/opencdc"
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit-connector-sdk/internal"
@@ -39,10 +40,10 @@ func TestSourceWithSchemaExtractionConfig_Apply(t *testing.T) {
 	is := is.New(t)
 
 	wantCfg := SourceWithSchemaExtractionConfig{
-		PayloadEnabled: ptr(true),
-		KeyEnabled:     ptr(true),
-		PayloadSubject: ptr("foo"),
-		KeySubject:     ptr("bar"),
+		PayloadEnabled: lang.Ptr(true),
+		KeyEnabled:     lang.Ptr(true),
+		PayloadSubject: lang.Ptr("foo"),
+		KeySubject:     lang.Ptr("bar"),
 	}
 
 	have := &SourceWithSchemaExtraction{}
@@ -108,8 +109,8 @@ func TestSourceWithSchemaExtraction_Configure(t *testing.T) {
 		name: "disabled by default",
 		middleware: SourceWithSchemaExtraction{
 			Config: SourceWithSchemaExtractionConfig{
-				PayloadEnabled: ptr(false),
-				KeyEnabled:     ptr(false),
+				PayloadEnabled: lang.Ptr(false),
+				KeyEnabled:     lang.Ptr(false),
 			},
 		},
 		have: config.Config{},
@@ -132,8 +133,8 @@ func TestSourceWithSchemaExtraction_Configure(t *testing.T) {
 		name: "static default payload subject",
 		middleware: SourceWithSchemaExtraction{
 			Config: SourceWithSchemaExtractionConfig{
-				PayloadSubject: ptr("foo"),
-				KeySubject:     ptr("bar"),
+				PayloadSubject: lang.Ptr("foo"),
+				KeySubject:     lang.Ptr("bar"),
 			},
 		},
 		have: config.Config{},
@@ -478,8 +479,8 @@ func TestSourceWithSchemaContext_Parameters(t *testing.T) {
 		{
 			name: "custom middleware config",
 			mwCfg: SourceWithSchemaContextConfig{
-				Enabled: ptr(false),
-				Name:    ptr("foobar"),
+				Enabled: lang.Ptr(false),
+				Name:    lang.Ptr("foobar"),
 			},
 			wantParams: config.Parameters{
 				"sdk.schema.context.enabled": {
@@ -545,8 +546,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "custom context in middleware, no user config",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enabled: ptr(true),
-				Name:    ptr("foobar"),
+				Enabled: lang.Ptr(true),
+				Name:    lang.Ptr("foobar"),
 			},
 			connectorCfg:    config.Config{},
 			wantContextName: "foobar",
@@ -554,8 +555,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "middleware config: use context false, no user config",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enabled: ptr(false),
-				Name:    ptr("foobar"),
+				Enabled: lang.Ptr(false),
+				Name:    lang.Ptr("foobar"),
 			},
 			connectorCfg:    config.Config{},
 			wantContextName: "",
@@ -563,8 +564,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "user config overrides use context",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enabled: ptr(false),
-				Name:    ptr("foobar"),
+				Enabled: lang.Ptr(false),
+				Name:    lang.Ptr("foobar"),
 			},
 			connectorCfg: config.Config{
 				"sdk.schema.context.enabled": "true",
@@ -574,8 +575,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "user config overrides context name, non-empty",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enabled: ptr(true),
-				Name:    ptr("foobar"),
+				Enabled: lang.Ptr(true),
+				Name:    lang.Ptr("foobar"),
 			},
 			connectorCfg: config.Config{
 				"sdk.schema.context.use":  "true",
@@ -586,8 +587,8 @@ func TestSourceWithSchemaContext_Configure(t *testing.T) {
 		{
 			name: "user config overrides context name, empty",
 			middlewareCfg: SourceWithSchemaContextConfig{
-				Enabled: ptr(true),
-				Name:    ptr("foobar"),
+				Enabled: lang.Ptr(true),
+				Name:    lang.Ptr("foobar"),
 			},
 			connectorCfg: config.Config{
 				"sdk.schema.context.use":  "true",

--- a/source_test.go
+++ b/source_test.go
@@ -137,6 +137,7 @@ func TestSourcePluginAdapter_Run(t *testing.T) {
 	src.EXPECT().Open(gomock.Any(), nil).Return(nil)
 
 	// first produce "normal" records, then produce last record, then return ErrBackoffRetry
+	src.EXPECT().ReadBatch(gomock.Any()).Return(nil, ErrUnimplemented)
 	r1 := src.EXPECT().Read(gomock.Any()).Return(want, nil).Times(recordCount - 1)
 	r2 := src.EXPECT().Read(gomock.Any()).Return(wantLast, nil).After(r1)
 	src.EXPECT().Read(gomock.Any()).Return(opencdc.Record{}, ErrBackoffRetry).After(r2)
@@ -209,6 +210,7 @@ func TestSourcePluginAdapter_Run_Stuck(t *testing.T) {
 	src.EXPECT().Open(gomock.Any(), nil).Return(nil)
 
 	// first produce "normal" records, then produce last record, then return ErrBackoffRetry
+	src.EXPECT().ReadBatch(gomock.Any()).Return(nil, ErrUnimplemented)
 	r1 := src.EXPECT().Read(gomock.Any()).Return(want, nil)
 	src.EXPECT().Read(gomock.Any()).DoAndReturn(func(ctx context.Context) (opencdc.Record, error) {
 		<-make(chan struct{}) // block forever and ever
@@ -267,6 +269,7 @@ func TestSourcePluginAdapter_Stop_WaitsForRun(t *testing.T) {
 	src.EXPECT().Open(gomock.Any(), nil).Return(nil)
 
 	// produce one record, then return ErrBackoffRetry
+	src.EXPECT().ReadBatch(gomock.Any()).Return(nil, ErrUnimplemented)
 	r1 := src.EXPECT().Read(gomock.Any()).Return(want, nil)
 	src.EXPECT().Read(gomock.Any()).Return(opencdc.Record{}, ErrBackoffRetry).After(r1.Call)
 
@@ -322,6 +325,7 @@ func TestSourcePluginAdapter_Teardown(t *testing.T) {
 	srcPlugin.state.Set(internal.StateConfigured) // Open expects state Configured
 
 	src.EXPECT().Open(gomock.Any(), nil).Return(nil)
+	src.EXPECT().ReadBatch(gomock.Any()).Return(nil, ErrUnimplemented)
 	r1 := src.EXPECT().Read(gomock.Any()).Return(opencdc.Record{}, nil)
 	src.EXPECT().Read(gomock.Any()).Return(opencdc.Record{}, ErrBackoffRetry).After(r1.Call)
 

--- a/unimplemented.go
+++ b/unimplemented.go
@@ -90,6 +90,11 @@ func (UnimplementedSource) Read(context.Context) (opencdc.Record, error) {
 	return opencdc.Record{}, fmt.Errorf("action \"Read\": %w", ErrUnimplemented)
 }
 
+// ReadBatch calls Read by default.
+func (s UnimplementedSource) ReadBatch(context.Context) ([]opencdc.Record, error) {
+	return nil, fmt.Errorf("action \"ReadBatch\": %w", ErrUnimplemented)
+}
+
 // Ack should be overridden if acks need to be forwarded to the source,
 // otherwise it is optional.
 func (UnimplementedSource) Ack(context.Context, opencdc.Position) error {


### PR DESCRIPTION
### Description

This PR adds the source middleware `SourceWithBatch` which enables source connectors to send records in batches to Conduit, which improves the performance.

The source connector developer doesn't have to change anything, existing connectors can benefit from this middleware. Although, notice that the `Source` middleware now also allows the implementation of `ReadBatch`, which allows the connector developer to return whole batches directly.

This PR also updates the destination connector to accept and correctly handle batches received from Conduit. Previously the batch was broken up into separate records. Now a batch is handled as is.

> [!NOTE]
> These changes should _not_ have an impact on the current behavior of connectors. However, they allow us to significantly improve the performance once we change the Conduit internals to handle batches end-to-end.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
