### PR TITLE
Encode key and payload whenever a schema is available

### DIFF
--- a/source_middleware.go
+++ b/source_middleware.go
@@ -669,6 +669,7 @@ func (s *sourceWithEncoding) schemaForKey(ctx context.Context, rec opencdc.Recor
 		// not both, this isn't valid.
 		return nil, fmt.Errorf("found metadata fields %v=%v and %v=%v, expected key schema subject and version to be both set to valid values, this is a bug in the connector", opencdc.MetadataKeySchemaSubject, subject, opencdc.MetadataKeySchemaVersion, version)
 	default:
+		//nolint:nilnil // we return nil to indicate that no schema is attached
 		return nil, nil
 	}
 }
@@ -739,6 +740,7 @@ func (s *sourceWithEncoding) schemaForPayload(ctx context.Context, rec opencdc.R
 		// not both, this isn't valid.
 		return nil, fmt.Errorf("found metadata fields %v=%v and %v=%v, expected payload schema subject and version to be both set to valid values, this is a bug in the connector", opencdc.MetadataPayloadSchemaSubject, subject, opencdc.MetadataPayloadSchemaVersion, version)
 	default:
+		//nolint:nilnil // we return nil to indicate that no schema is attached
 		return nil, nil
 	}
 }

--- a/source_middleware.go
+++ b/source_middleware.go
@@ -618,7 +618,7 @@ func (s *sourceWithEncoding) encodeKey(ctx context.Context, rec *opencdc.Record)
 	if _, ok := rec.Key.(opencdc.StructuredData); !ok {
 		// log warning once, to avoid spamming the logs
 		s.keyWarnOnce.Do(func() {
-			Logger(ctx).Warn().Msgf(`record key is not structured, consider disabling the source schema key encoding using "%s: false"`, configSourceSchemaExtractionKeyEnabled)
+			Logger(ctx).Warn().Msg(`record keys produced by this connector are not structured and won't be encoded"`)
 		})
 		return nil
 	}
@@ -679,7 +679,7 @@ func (s *sourceWithEncoding) encodePayload(ctx context.Context, rec *opencdc.Rec
 	if !beforeIsStructured && !afterIsStructured {
 		// log warning once, to avoid spamming the logs
 		s.payloadWarnOnce.Do(func() {
-			Logger(ctx).Warn().Msgf(`record payload is not structured, consider disabling the source schema payload encoding using "%s: false"`, configSourceSchemaExtractionPayloadEnabled)
+			Logger(ctx).Warn().Msg(`record payloads produced by this connector are not structured and won't be encoded"`)
 		})
 		return nil
 	}

--- a/source_middleware.go
+++ b/source_middleware.go
@@ -170,8 +170,8 @@ func (c SourceWithSchemaExtractionConfig) types() []string {
 	return out
 }
 
-// SourceWithSchemaExtraction is a middleware that extracts and encodes the record
-// payload and key with a schema. The schema is extracted from the record data
+// SourceWithSchemaExtraction is a middleware that extracts a record's
+// payload and key schemas. The schema is extracted from the record data
 // for each record produced by the source. The schema is registered with the
 // schema service and the schema subject is attached to the record metadata.
 type SourceWithSchemaExtraction struct {
@@ -583,6 +583,9 @@ func (s *sourceWithSchemaContext) LifecycleOnDeleted(ctx context.Context, config
 
 // -- SourceWithEncoding ------------------------------------------------------
 
+// SourceWithEncoding is a middleware that encodes the record payload and key
+// with the provided schema. The schema is registered with the schema service
+// and the schema subject is attached to the record metadata.
 type SourceWithEncoding struct {
 }
 
@@ -593,6 +596,7 @@ func (s SourceWithEncoding) Wrap(impl Source) Source {
 	return &sourceWithEncoding{Source: impl}
 }
 
+// sourceWithEncoding is the actual middleware implementation.
 type sourceWithEncoding struct {
 	Source
 

--- a/source_middleware.go
+++ b/source_middleware.go
@@ -353,7 +353,7 @@ func (s *sourceWithSchemaExtraction) extractAttachPayloadSchema(ctx context.Cont
 	if s.payloadSubject == "" {
 		return nil // payload schema encoding is disabled
 	}
-	if rec.Payload.After == nil {
+	if (rec.Payload == opencdc.Change{}) {
 		return nil
 	}
 

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -422,9 +422,9 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				is.True(errors.Is(err, opencdc.ErrMetadataFieldNotFound))
 			}
 
-			is.Equal("", cmp.Diff(gotKey, wantKey))
-			is.Equal("", cmp.Diff(gotPayloadBefore, wantPayloadBefore))
-			is.Equal("", cmp.Diff(gotPayloadAfter, wantPayloadAfter))
+			is.Equal("", cmp.Diff(wantKey, gotKey))
+			is.Equal("", cmp.Diff(wantPayloadBefore, gotPayloadBefore))
+			is.Equal("", cmp.Diff(wantPayloadAfter, gotPayloadAfter))
 		})
 	}
 }
@@ -906,6 +906,7 @@ func TestSourceWithEncoding_Read(t *testing.T) {
 			gotPayloadBefore := got.Payload.Before
 			gotPayloadAfter := got.Payload.After
 
+			// if the test case expects the resulting key to be structured
 			if _, ok := wantKey.(opencdc.StructuredData); ok {
 				subject, err := got.Metadata.GetKeySchemaSubject()
 				is.NoErr(err)
@@ -951,9 +952,9 @@ func TestSourceWithEncoding_Read(t *testing.T) {
 				}
 			}
 
-			is.Equal("", cmp.Diff(gotKey, wantKey))
-			is.Equal("", cmp.Diff(gotPayloadBefore, wantPayloadBefore))
-			is.Equal("", cmp.Diff(gotPayloadAfter, wantPayloadAfter))
+			is.Equal("", cmp.Diff(wantKey, gotKey))
+			is.Equal("", cmp.Diff(wantPayloadBefore, gotPayloadBefore))
+			is.Equal("", cmp.Diff(wantPayloadAfter, gotPayloadAfter))
 		})
 	}
 }

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -393,12 +393,6 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				is.NoErr(err)
 
 				is.Equal("", cmp.Diff(wantSchema, string(sch.Bytes)))
-
-				var sd opencdc.StructuredData
-				err = sch.Unmarshal(gotKey.Bytes(), &sd)
-				is.NoErr(err)
-
-				gotKey = sd
 			} else {
 				_, err := got.Metadata.GetKeySchemaSubject()
 				is.True(errors.Is(err, opencdc.ErrMetadataFieldNotFound))
@@ -421,19 +415,6 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				is.NoErr(err)
 
 				is.Equal("", cmp.Diff(wantSchema, string(sch.Bytes)))
-
-				if isPayloadBeforeStructured {
-					var sd opencdc.StructuredData
-					err = sch.Unmarshal(gotPayloadBefore.Bytes(), &sd)
-					is.NoErr(err)
-					gotPayloadBefore = sd
-				}
-				if isPayloadAfterStructured {
-					var sd opencdc.StructuredData
-					err = sch.Unmarshal(gotPayloadAfter.Bytes(), &sd)
-					is.NoErr(err)
-					gotPayloadAfter = sd
-				}
 			} else {
 				_, err := got.Metadata.GetPayloadSchemaSubject()
 				is.True(errors.Is(err, opencdc.ErrMetadataFieldNotFound))
@@ -653,4 +634,278 @@ func TestSourceWithSchemaContext_ContextValue(t *testing.T) {
 
 	err = underTest.Open(ctx, opencdc.Position{})
 	is.NoErr(err)
+}
+
+// -- SourceWithEncoding ------------------------------------------------------
+
+func TestSourceWithEncoding_Read(t *testing.T) {
+	is := is.New(t)
+	ctrl := gomock.NewController(t)
+	src := NewMockSource(ctrl)
+	ctx := context.Background()
+
+	s := (&SourceWithSchemaExtraction{}).Wrap(src)
+
+	src.EXPECT().Configure(ctx, gomock.Any()).Return(nil)
+	err := s.Configure(ctx, config.Config{})
+	is.NoErr(err)
+
+	testStructuredData := opencdc.StructuredData{
+		"foo":   "bar",
+		"long":  int64(1),
+		"float": 2.34,
+		"time":  time.Now().UTC().Truncate(time.Microsecond), // avro precision is microseconds
+	}
+	wantSchema := `{"name":"record","type":"record","fields":[{"name":"float","type":"double"},{"name":"foo","type":"string"},{"name":"long","type":"long"},{"name":"time","type":{"type":"long","logicalType":"timestamp-micros"}}]}`
+
+	customTestSchema, err := schema.Create(ctx, schema.TypeAvro, "custom-test-schema", []byte(wantSchema))
+	is.NoErr(err)
+
+	testCases := []struct {
+		name               string
+		record             opencdc.Record
+		wantKeySubject     string
+		wantPayloadSubject string
+	}{{
+		name: "no key, no payload",
+		record: opencdc.Record{
+			Key: nil,
+			Payload: opencdc.Change{
+				Before: nil,
+				After:  nil,
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "raw key",
+		record: opencdc.Record{
+			Key: opencdc.RawData("this should not be encoded"),
+			Payload: opencdc.Change{
+				Before: nil,
+				After:  nil,
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "structured key",
+		record: opencdc.Record{
+			Key: testStructuredData.Clone(),
+			Payload: opencdc.Change{
+				Before: nil,
+				After:  nil,
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "raw payload before",
+		record: opencdc.Record{
+			Key: nil,
+			Payload: opencdc.Change{
+				Before: opencdc.RawData("this should not be encoded"),
+				After:  nil,
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "structured payload before",
+		record: opencdc.Record{
+			Key: nil,
+			Payload: opencdc.Change{
+				Before: testStructuredData.Clone(),
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "raw payload after",
+		record: opencdc.Record{
+			Key: nil,
+			Payload: opencdc.Change{
+				Before: nil,
+				After:  opencdc.RawData("this should not be encoded"),
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "structured payload after",
+		record: opencdc.Record{
+			Key: nil,
+			Payload: opencdc.Change{
+				Before: nil,
+				After:  testStructuredData.Clone(),
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "all structured",
+		record: opencdc.Record{
+			Key: testStructuredData.Clone(),
+			Payload: opencdc.Change{
+				Before: testStructuredData.Clone(),
+				After:  testStructuredData.Clone(),
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "all raw",
+		record: opencdc.Record{
+			Key: opencdc.RawData("this should not be encoded"),
+			Payload: opencdc.Change{
+				Before: opencdc.RawData("this should not be encoded"),
+				After:  opencdc.RawData("this should not be encoded"),
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "key raw payload structured",
+		record: opencdc.Record{
+			Key: opencdc.RawData("this should not be encoded"),
+			Payload: opencdc.Change{
+				Before: nil,
+				After:  testStructuredData.Clone(),
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "key structured payload raw",
+		record: opencdc.Record{
+			Key: testStructuredData.Clone(),
+			Payload: opencdc.Change{
+				Before: opencdc.RawData("this should not be encoded"),
+				After:  nil,
+			},
+		},
+		wantKeySubject:     "key",
+		wantPayloadSubject: "payload",
+	}, {
+		name: "all structured with collection",
+		record: opencdc.Record{
+			Metadata: map[string]string{
+				opencdc.MetadataCollection: "foo",
+			},
+			Key: testStructuredData.Clone(),
+			Payload: opencdc.Change{
+				Before: testStructuredData.Clone(),
+				After:  testStructuredData.Clone(),
+			},
+		},
+		wantKeySubject:     "foo.key",
+		wantPayloadSubject: "foo.payload",
+	}, {
+		name: "all structured with collection and predefined schema",
+		record: opencdc.Record{
+			Metadata: map[string]string{
+				opencdc.MetadataCollection:           "foo",
+				opencdc.MetadataKeySchemaSubject:     customTestSchema.Subject,
+				opencdc.MetadataKeySchemaVersion:     strconv.Itoa(customTestSchema.Version),
+				opencdc.MetadataPayloadSchemaSubject: customTestSchema.Subject,
+				opencdc.MetadataPayloadSchemaVersion: strconv.Itoa(customTestSchema.Version),
+			},
+			Key: testStructuredData.Clone(),
+			Payload: opencdc.Change{
+				Before: testStructuredData.Clone(),
+				After:  testStructuredData.Clone(),
+			},
+		},
+		wantKeySubject:     customTestSchema.Subject,
+		wantPayloadSubject: customTestSchema.Subject,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			src.EXPECT().Read(ctx).Return(tc.record, nil)
+
+			var wantKey, wantPayloadBefore, wantPayloadAfter opencdc.Data
+			if tc.record.Key != nil {
+				wantKey = tc.record.Key.Clone()
+			}
+			if tc.record.Payload.Before != nil {
+				wantPayloadBefore = tc.record.Payload.Before.Clone()
+			}
+			if tc.record.Payload.After != nil {
+				wantPayloadAfter = tc.record.Payload.After.Clone()
+			}
+
+			got, err := s.Read(ctx)
+			is.NoErr(err)
+
+			gotKey := got.Key
+			gotPayloadBefore := got.Payload.Before
+			gotPayloadAfter := got.Payload.After
+
+			if _, ok := wantKey.(opencdc.StructuredData); ok {
+				subject, err := got.Metadata.GetKeySchemaSubject()
+				is.NoErr(err)
+				version, err := got.Metadata.GetKeySchemaVersion()
+				is.NoErr(err)
+
+				is.Equal(subject, tc.wantKeySubject)
+				is.Equal(version, 1)
+
+				sch, err := schema.Get(ctx, subject, version)
+				is.NoErr(err)
+
+				is.Equal("", cmp.Diff(wantSchema, string(sch.Bytes)))
+
+				var sd opencdc.StructuredData
+				err = sch.Unmarshal(gotKey.Bytes(), &sd)
+				is.NoErr(err)
+
+				gotKey = sd
+			} else {
+				_, err := got.Metadata.GetKeySchemaSubject()
+				is.True(errors.Is(err, opencdc.ErrMetadataFieldNotFound))
+				_, err = got.Metadata.GetKeySchemaVersion()
+				is.True(errors.Is(err, opencdc.ErrMetadataFieldNotFound))
+			}
+
+			_, isPayloadBeforeStructured := wantPayloadBefore.(opencdc.StructuredData)
+			_, isPayloadAfterStructured := wantPayloadAfter.(opencdc.StructuredData)
+			if isPayloadBeforeStructured || isPayloadAfterStructured {
+				subject, err := got.Metadata.GetPayloadSchemaSubject()
+				is.NoErr(err)
+				version, err := got.Metadata.GetPayloadSchemaVersion()
+				is.NoErr(err)
+
+				is.Equal(subject, tc.wantPayloadSubject)
+				is.Equal(version, 1)
+
+				sch, err := schema.Get(ctx, subject, version)
+				is.NoErr(err)
+
+				is.Equal("", cmp.Diff(wantSchema, string(sch.Bytes)))
+
+				if isPayloadBeforeStructured {
+					var sd opencdc.StructuredData
+					err = sch.Unmarshal(gotPayloadBefore.Bytes(), &sd)
+					is.NoErr(err)
+					gotPayloadBefore = sd
+				}
+				if isPayloadAfterStructured {
+					var sd opencdc.StructuredData
+					err = sch.Unmarshal(gotPayloadAfter.Bytes(), &sd)
+					is.NoErr(err)
+					gotPayloadAfter = sd
+				}
+			} else {
+				_, err := got.Metadata.GetPayloadSchemaSubject()
+				is.True(errors.Is(err, opencdc.ErrMetadataFieldNotFound))
+				_, err = got.Metadata.GetPayloadSchemaVersion()
+				is.True(errors.Is(err, opencdc.ErrMetadataFieldNotFound))
+			}
+
+			is.Equal("", cmp.Diff(gotKey, wantKey))
+			is.Equal("", cmp.Diff(gotPayloadBefore, wantPayloadBefore))
+			is.Equal("", cmp.Diff(gotPayloadAfter, wantPayloadAfter))
+		})
+	}
 }

--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -362,7 +362,7 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			src.EXPECT().Read(ctx).Return(tc.record, nil)
+			src.EXPECT().ReadN(ctx, 1).Return([]opencdc.Record{tc.record}, nil)
 
 			var wantKey, wantPayloadBefore, wantPayloadAfter opencdc.Data
 			if tc.record.Key != nil {
@@ -375,9 +375,11 @@ func TestSourceWithSchemaExtraction_Read(t *testing.T) {
 				wantPayloadAfter = tc.record.Payload.After.Clone()
 			}
 
-			got, err := s.Read(ctx)
+			gotN, err := s.ReadN(ctx, 1)
 			is.NoErr(err)
+			is.Equal(1, len(gotN))
 
+			got := gotN[0]
 			gotKey := got.Key
 			gotPayloadBefore := got.Payload.Before
 			gotPayloadAfter := got.Payload.After


### PR DESCRIPTION
### Description

Fixes https://github.com/ConduitIO/conduit-connector-sdk/issues/197.

Previously, encoding a record's data was tied to the flag enabling schema extraction. This PR makes sure that encoding happens whenever there's a schema available and the data is structured. Since extraction and encoding are separate actions, the middleware has also been split.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
