### PR TITLE
Allow wildcard in param name

### DIFF
--- a/acceptance_testing.go
+++ b/acceptance_testing.go
@@ -555,7 +555,7 @@ func (a acceptanceTest) TestSource_Parameters_Success(t *testing.T) {
 	is.True(params != nil)   // Source.Parameters() shouldn't return nil
 	is.True(len(params) > 0) // Source.Parameters() shouldn't return empty map
 
-	paramNameRegex := regexp.MustCompile(`^[a-zA-Z0-9.]+$`)
+	paramNameRegex := regexp.MustCompile(`^[a-zA-Z0-9.*]+$`)
 	for name, p := range params {
 		is.True(paramNameRegex.MatchString(name)) // parameter contains invalid characters
 		is.True(p.Description != "")              // parameter description is empty


### PR DESCRIPTION
### Description

We introduced dynamic configuration parameters (https://github.com/ConduitIO/conduit-commons/pull/35) that allow wildcards in parameter names. This PR changes one of the acceptance tests to allow the wildcard in a parameter name.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
