### PR TITLE
sourceWithEncoding middleware works impropertly in combination with sourceWithBatch

### DIFF
--- a/source_middleware_test.go
+++ b/source_middleware_test.go
@@ -664,19 +664,23 @@ func TestSourceWithEncoding_ReadN(t *testing.T) {
 		name: "no records returned",
 	}, {
 		name: "single record returned",
-		inputRecs: []opencdc.Record{{
-			Key: testDataStruct.Clone(),
-			Payload: opencdc.Change{
-				Before: testDataStruct.Clone(),
-				After:  testDataStruct.Clone(),
-			}},
+		inputRecs: []opencdc.Record{
+			{
+				Key: testDataStruct.Clone(),
+				Payload: opencdc.Change{
+					Before: testDataStruct.Clone(),
+					After:  testDataStruct.Clone(),
+				},
+			},
 		},
-		wantRecs: []opencdc.Record{{
-			Key: testDataRaw,
-			Payload: opencdc.Change{
-				Before: testDataRaw,
-				After:  testDataRaw,
-			}},
+		wantRecs: []opencdc.Record{
+			{
+				Key: testDataRaw,
+				Payload: opencdc.Change{
+					Before: testDataRaw,
+					After:  testDataRaw,
+				},
+			},
 		},
 	}, {
 		name: "multiple records returned",


### PR DESCRIPTION
### Description

sourceWithEncoding works not propertly in combination with sourceWithBatch middleware.

sourcePluginAdapter in runRead method first tries to call ReadN method and if it fails with Unimplemented error, it fallbacks on Read method.
If Source implementation supports ReadN method, this method will be called instead of Read and the result will not be encoded propertly.

If Source doesn't implement ReadN method, but supports batches using sourceWithBatch middleware the result is the same: records are not encoded.

Fixes # (issue)

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
