### PR TITLE
conn-sdk-cli: use text/template, fix flag name

### DIFF
--- a/conn-sdk-cli/main.go
+++ b/conn-sdk-cli/main.go
@@ -57,7 +57,7 @@ func main() {
 		},
 	}
 	cmdSpecgen.Flags().StringP("output", "o", "connector.yaml", "name of the output file")
-	cmdSpecgen.Flags().StringP("package", "p", ".", "path to the package that contains the Connector variable")
+	cmdSpecgen.Flags().StringP("path", "p", ".", "path to the package that contains the Connector variable")
 
 	cmdRoot.AddCommand(
 		cmdReadmegen,

--- a/conn-sdk-cli/specgen/cmd.go
+++ b/conn-sdk-cli/specgen/cmd.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"html/template"
 	"io"
 	"log"
 	"os"
@@ -26,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"text/template"
 )
 
 type Command struct {


### PR DESCRIPTION
### Description

1. Currently, conn-sdk-cli uses `html/template` which means that the program to extract the specification uses the following import `pkg_ &#34;github.com/conduitio/conduit-connector-postgres&#34;`, which breaks the program.
2. A flag name was wrong, which caused a nil pointer dereference panic.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
