### PR TITLE
Add specs and version command

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/pconnector/server"
 	"github.com/conduitio/conduit-connector-protocol/pconnutils"
 	"github.com/conduitio/conduit-connector-sdk/internal"
+	"github.com/conduitio/yaml/v3"
 	"github.com/rs/zerolog"
 )
 
@@ -37,10 +38,28 @@ import (
 //
 // Plugins should call Serve in their main() functions.
 func Serve(c Connector) {
+	handleCommand(c, os.Args[1:])
+
 	err := serve(c)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error running plugin: %+v", err)
 		os.Exit(1)
+	}
+}
+
+func handleCommand(c Connector, args []string) {
+	if len(args) == 0 {
+		return
+	}
+
+	switch args[0] {
+	case "spec", "specs", "specification", "specifications":
+		out, err := yaml.Marshal(c.NewSpecification())
+		if err != nil {
+			panic(fmt.Errorf("failed to marshal specification: %w", err))
+		}
+		fmt.Println(string(out))
+		os.Exit(0)
 	}
 }
 

--- a/serve.go
+++ b/serve.go
@@ -62,6 +62,12 @@ func handleCommand(c Connector, args []string) {
 		}
 		fmt.Println(string(out))
 		os.Exit(0)
+	case "version":
+		fmt.Println(c.NewSpecification().Version)
+		os.Exit(0)
+	default:
+		fmt.Println("unknown command")
+		os.Exit(1)
 	}
 }
 

--- a/serve.go
+++ b/serve.go
@@ -66,7 +66,7 @@ func handleCommand(c Connector, args []string) {
 		fmt.Println(c.NewSpecification().Version)
 		os.Exit(0)
 	default:
-		fmt.Println("unknown command")
+		fmt.Println("unknown command:", args[0])
 		os.Exit(1)
 	}
 }

--- a/serve.go
+++ b/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/conduitio/conduit-connector-protocol/pconnector"
 	"github.com/conduitio/conduit-connector-protocol/pconnector/server"
 	"github.com/conduitio/conduit-connector-protocol/pconnutils"
+	v1 "github.com/conduitio/conduit-connector-sdk/conn-sdk-cli/specgen/model/v1"
 	"github.com/conduitio/conduit-connector-sdk/internal"
 	"github.com/conduitio/yaml/v3"
 	"github.com/rs/zerolog"
@@ -54,7 +55,8 @@ func handleCommand(c Connector, args []string) {
 
 	switch args[0] {
 	case "spec", "specs", "specification", "specifications":
-		out, err := yaml.Marshal(c.NewSpecification())
+		spec := v1.Specification{}.FromConfig(c.NewSpecification())
+		out, err := yaml.Marshal(spec)
 		if err != nil {
 			panic(fmt.Errorf("failed to marshal specification: %w", err))
 		}


### PR DESCRIPTION
### Description

Adds the ability to get the specs in the CLI from a standalone connector. You can use `spec`, `specs`, `specification` or `specifications` to print the `connector.yaml` stored in the connector.

<details>
  <summary>Example output of the postgres connector</summary>

```
$ ./conduit-connector-postgres specs
version: "1.0"
specification:
    name: postgres
    summary: A PostgreSQL source and destination plugin for Conduit.
    description: ""
    version: v0.10.1-34-g179ac45-dirty
    author: Meroxa, Inc.
    source:
        parameters:
            - name: url
              description: URL is the connection string for the Postgres database.
              type: string
              default: ""
              validations:
                - type: required
                  value: ""
            - name: cdcMode
              description: CDCMode determines how the connector should listen to changes.
              type: string
              default: auto
              validations:
                - type: inclusion
                  value: auto,logrepl
            - name: logrepl.autoCleanup
              description: |-
                LogreplAutoCleanup determines if the replication slot and publication should be
                removed when the connector is deleted.
              type: bool
              default: "true"
              validations: []
            - name: logrepl.publicationName
              description: |-
                LogreplPublicationName determines the publication name in case the
                connector uses logical replication to listen to changes (see CDCMode).
              type: string
              default: conduitpub
              validations: []
            - name: logrepl.slotName
              description: |-
                LogreplSlotName determines the replication slot name in case the
                connector uses logical replication to listen to changes (see CDCMode).
              type: string
              default: conduitslot
              validations: []
            - name: logrepl.withAvroSchema
              description: |-
                WithAvroSchema determines whether the connector should attach an avro schema on each
                record.
              type: bool
              default: "false"
              validations: []
            - name: sdk.batch.delay
              description: Maximum delay before an incomplete batch is read from the source.
              type: duration
              default: "0"
              validations:
                - type: greater-than
                  value: "-1"
            - name: sdk.batch.size
              description: Maximum size of batch before it gets read from the source.
              type: int
              default: "0"
              validations:
                - type: greater-than
                  value: "-1"
            - name: sdk.schema.context.enabled
              description: |-
                Specifies whether to use a schema context name. If set to false, no schema context name will
                be used, and schemas will be saved with the subject name specified in the connector
                (not safe because of name conflicts).
              type: bool
              default: "true"
              validations: []
            - name: sdk.schema.context.name
              description: |-
                Schema context name to be used. Used as a prefix for all schema subject names.
                If empty, defaults to the connector ID.
              type: string
              default: ""
              validations: []
            - name: sdk.schema.extract.key.enabled
              description: Whether to extract and encode the record key with a schema.
              type: bool
              default: "false"
              validations: []
            - name: sdk.schema.extract.key.subject
              description: |-
                The subject of the key schema. If the record metadata contains the field
                "opencdc.collection" it is prepended to the subject name and separated
                with a dot.
              type: string
              default: key
              validations: []
            - name: sdk.schema.extract.payload.enabled
              description: Whether to extract and encode the record payload with a schema.
              type: bool
              default: "false"
              validations: []
            - name: sdk.schema.extract.payload.subject
              description: |-
                The subject of the payload schema. If the record metadata contains the
                field "opencdc.collection" it is prepended to the subject name and
                separated with a dot.
              type: string
              default: payload
              validations: []
            - name: sdk.schema.extract.type
              description: The type of the payload schema.
              type: string
              default: avro
              validations:
                - type: inclusion
                  value: avro
            - name: snapshot.fetchSize
              description: Snapshot fetcher size determines the number of rows to retrieve at a time.
              type: int
              default: "50000"
              validations: []
            - name: snapshotMode
              description: SnapshotMode is whether the plugin will take a snapshot of the entire table before starting cdc mode.
              type: string
              default: initial
              validations:
                - type: inclusion
                  value: initial,never
            - name: table
              description: 'Deprecated: use `tables` instead.'
              type: string
              default: ""
              validations: []
            - name: tables
              description: |-
                Tables is a List of table names to read from, separated by a comma, e.g.:"table1,table2".
                Use "*" if you'd like to listen to all tables.
              type: string
              default: ""
              validations: []
    destination:
        parameters:
            - name: url
              description: URL is the connection string for the Postgres database.
              type: string
              default: ""
              validations:
                - type: required
                  value: ""
            - name: key
              description: Key represents the column name for the key used to identify and update existing rows.
              type: string
              default: ""
              validations: []
            - name: sdk.batch.delay
              description: Maximum delay before an incomplete batch is written to the destination.
              type: duration
              default: "0"
              validations: []
            - name: sdk.batch.size
              description: Maximum size of batch before it gets written to the destination.
              type: int
              default: "0"
              validations:
                - type: greater-than
                  value: "-1"
            - name: sdk.rate.burst
              description: |-
                Allow bursts of at most X records (0 or less means that bursts are not
                limited). Only takes effect if a rate limit per second is set. Note that
                if `sdk.batch.size` is bigger than `sdk.rate.burst`, the effective batch
                size will be equal to `sdk.rate.burst`.
              type: int
              default: "0"
              validations:
                - type: greater-than
                  value: "-1"
            - name: sdk.rate.perSecond
              description: Maximum number of records written per second (0 means no rate limit).
              type: float
              default: "0"
              validations:
                - type: greater-than
                  value: "-1"
            - name: sdk.record.format
              description: |-
                The format of the output record. See the Conduit documentation for a full
                list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
              type: string
              default: opencdc/json
              validations: []
            - name: sdk.record.format.options
              description: |-
                Options to configure the chosen output record format. Options are normally
                key=value pairs separated with comma (e.g. opt1=val2,opt2=val2), except
                for the `template` record format, where options are a Go template.
              type: string
              default: ""
              validations: []
            - name: sdk.schema.extract.key.enabled
              description: Whether to extract and decode the record key with a schema.
              type: bool
              default: "true"
              validations: []
            - name: sdk.schema.extract.payload.enabled
              description: Whether to extract and decode the record payload with a schema.
              type: bool
              default: "true"
              validations: []
            - name: table
              description: Table is used as the target table into which records are inserted.
              type: string
              default: '{{ index .Metadata "opencdc.collection" }}'
              validations: []
```

</details>

I also added the `version` command, which simply prints the version:

```
$ ./conduit-connector-postgres version
v0.10.1-34-g179ac45-dirty
```

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.