### PR TITLE
Add new line before description

### DIFF
--- a/conn-sdk-cli/readmegen/generate_test.go
+++ b/conn-sdk-cli/readmegen/generate_test.go
@@ -48,7 +48,8 @@ func TestGenerate(t *testing.T) {
 
 Name: <!-- readmegen:name -->Test-Connector<!-- /readmegen:name -->
 Summary: <!-- readmegen:summary -->test summary<!-- /readmegen:summary -->
-Description: <!-- readmegen:description -->Test description
+Description: <!-- readmegen:description -->
+Test description
 should be able to handle new lines as well!
 <!-- /readmegen:description -->
 Version: <!-- readmegen:version -->v0.1.0<!-- /readmegen:version -->

--- a/conn-sdk-cli/readmegen/preprocess.go
+++ b/conn-sdk-cli/readmegen/preprocess.go
@@ -36,7 +36,7 @@ var (
 	preprocessTags = map[string]string{
 		"name":        `{{ title .specification.name }}`,
 		"summary":     `{{ .specification.summary }}`,
-		"description": `{{ .specification.description }}`,
+		"description": "\n" + `{{ .specification.description }}`,
 		"version":     `{{ .specification.version }}`,
 		"author":      `{{ .specification.author }}`,
 


### PR DESCRIPTION
### Description

A description is normally a multiline markdown document. Even more - I'll argue that it will most of the time start with a chapter (e.g. `## Source` or similar). For this to work, the line can't start with a HTML comment, so we add a new line in front to push the description start into a new line.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
