### PR TITLE
disable batch delay validations on SourceWithBatch middleware

### DIFF
--- a/conn-sdk-cli/specgen/testdata/custom_embedded_struct/want.yaml
+++ b/conn-sdk-cli/specgen/testdata/custom_embedded_struct/want.yaml
@@ -25,9 +25,7 @@ specification:
         description: Maximum delay before an incomplete batch is read from the source.
         type: duration
         default: "0"
-        validations:
-          - type: greater-than
-            value: "-1"
+        validations: []
       - name: sdk.batch.size
         description: Maximum size of batch before it gets read from the source.
         type: int

--- a/conn-sdk-cli/specgen/testdata/custom_middleware_config/want.yaml
+++ b/conn-sdk-cli/specgen/testdata/custom_middleware_config/want.yaml
@@ -16,9 +16,7 @@ specification:
         description: Maximum delay before an incomplete batch is read from the source.
         type: duration
         default: "0"
-        validations:
-          - type: greater-than
-            value: "-1"
+        validations: []
       - name: sdk.batch.size
         description: Maximum size of batch before it gets read from the source.
         type: int

--- a/conn-sdk-cli/specgen/testdata/param_sorting/want.yaml
+++ b/conn-sdk-cli/specgen/testdata/param_sorting/want.yaml
@@ -32,9 +32,7 @@ specification:
         description: Maximum delay before an incomplete batch is read from the source.
         type: duration
         default: "0"
-        validations:
-          - type: greater-than
-            value: "-1"
+        validations: []
       - name: sdk.batch.size
         description: Maximum size of batch before it gets read from the source.
         type: int

--- a/source_middleware.go
+++ b/source_middleware.go
@@ -648,7 +648,7 @@ type SourceWithBatch struct {
 	// Maximum size of batch before it gets read from the source.
 	BatchSize *int `json:"sdk.batch.size" default:"0" validate:"gt=-1"`
 	// Maximum delay before an incomplete batch is read from the source.
-	BatchDelay *time.Duration `json:"sdk.batch.delay" default:"0" validate:"gt=-1"`
+	BatchDelay *time.Duration `json:"sdk.batch.delay" default:"0"`
 }
 
 // Wrap a Source into the middleware.


### PR DESCRIPTION
### Description

Duration validations are not supported by conduit-common (https://github.com/ConduitIO/conduit-commons/issues/169)
This bug (?) doesn't allow to use batching.

There is no such validation in DestinationWithBatch and looks like this validation is pretty useless.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
