### PR TITLE
Fix issue with closing channel in SourceWithBatch

### DIFF
--- a/source_middleware.go
+++ b/source_middleware.go
@@ -724,10 +724,6 @@ func (s *sourceWithBatch) runReadN(ctx context.Context) {
 				}
 				continue
 
-			case errors.Is(err, context.Canceled):
-				s.readNCh <- readNResponse{Err: err}
-				return
-
 			case errors.Is(err, ErrUnimplemented):
 				Logger(ctx).Info().Msg("source does not support batch reads, falling back to single reads")
 
@@ -772,10 +768,6 @@ func (s *sourceWithBatch) runRead(ctx context.Context) {
 					return
 				}
 				continue
-			}
-			if errors.Is(err, context.Canceled) {
-				s.readNCh <- readNResponse{Err: err}
-				return
 			}
 
 			s.readCh <- readResponse{Err: err}


### PR DESCRIPTION
### Description

This PR fixes the issue described in the next paragraph.

#### The issue

When I was running a custom Conduit app:
* with a few additional built-in plugins
* a Mongo-to-Kafka pipeline
* and the new pipeline architecture enabled

I got the following error:

```
2025-02-28T08:33:57+00:00 DBG calling Teardown component=builtin.sourcePluginAdapter connector_id=mongo-to-kafka:mongo-source plugin_name=builtin:mongo plugin_type=source request={} request_id=0e13942c-ffe2-4c94-b342-2c44bec767ff
panic: send on closed channel

goroutine 174 [running]:
github.com/conduitio/conduit-connector-sdk.(*sourceWithBatch).runRead(0xc000a8ff40, {0x321b730, 0xc0008e2af0})
	/go/pkg/mod/github.com/conduitio/conduit-connector-sdk@v0.13.1/source_middleware.go:777 +0x453
created by github.com/conduitio/conduit-connector-sdk.(*sourceWithBatch).runReadN in goroutine 168
	/go/pkg/mod/github.com/conduitio/conduit-connector-sdk@v0.13.1/source_middleware.go:734 +0x38f
```

The full setup can be found here: https://github.com/hariso/conduit-performance-tests/tree/main/mongodb/conduit.

The issue appears to be [here](https://github.com/ConduitIO/conduit-connector-sdk/blob/e494a3645bb77ed6fef5dca4f3926c91c524c654/source_middleware.go#L776-L779):

```go
if errors.Is(err, context.Canceled) {
    s.readNCh <- readNResponse{Err: err}
    return
}
```

This code is from the `runRead`  method, that's supposed to use a source connector's `Read` method, and in this case it should close the `readCh` channel, not `readNCh`.

Also, `runRead` is only ever called from `runReadN`, when the middleware realizes that the `ReadN` method is not implemented. It also closes the `readNCh`, which is another reason why we shouldn't close `readNCh` in `runRead`.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
