### PR TITLE
Include type when generating yaml parameters

### DIFF
--- a/conn-sdk-cli/readmegen/preprocess.go
+++ b/conn-sdk-cli/readmegen/preprocess.go
@@ -40,9 +40,9 @@ var (
 		"version":     `{{ .specification.version }}`,
 		"author":      `{{ .specification.author }}`,
 
-		"source.parameters.yaml":       `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.source.parameters }}`,
+		"source.parameters.yaml":       `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.source.parameters "type" "source"}}`,
 		"source.parameters.table":      `{{ template "parameters.table" args "specification" .specification "parameters" .specification.source.parameters }}`,
-		"destination.parameters.yaml":  `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.destination.parameters }}`,
+		"destination.parameters.yaml":  `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.destination.parameters "type" "destination"}}`,
 		"destination.parameters.table": `{{ template "parameters.table" args "specification" .specification "parameters" .specification.destination.parameters }}`,
 	}
 	errReadmegenCommentNotFound = errors.New("readmegen open tag not found")

--- a/conn-sdk-cli/readmegen/preprocess.go
+++ b/conn-sdk-cli/readmegen/preprocess.go
@@ -40,9 +40,9 @@ var (
 		"version":     `{{ .specification.version }}`,
 		"author":      `{{ .specification.author }}`,
 
-		"source.parameters.yaml":       `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.source.parameters "type" "source"}}`,
+		"source.parameters.yaml":       `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.source.parameters "connectorType" "source"}}`,
 		"source.parameters.table":      `{{ template "parameters.table" args "specification" .specification "parameters" .specification.source.parameters }}`,
-		"destination.parameters.yaml":  `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.destination.parameters "type" "destination"}}`,
+		"destination.parameters.yaml":  `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.destination.parameters "connectorType" "destination"}}`,
 		"destination.parameters.table": `{{ template "parameters.table" args "specification" .specification "parameters" .specification.destination.parameters }}`,
 	}
 	errReadmegenCommentNotFound = errors.New("readmegen open tag not found")

--- a/conn-sdk-cli/readmegen/templates/parameters.yaml.tmpl
+++ b/conn-sdk-cli/readmegen/templates/parameters.yaml.tmpl
@@ -3,7 +3,7 @@
 version: 2.2
 pipelines:
   - id: example
-    type: {{ .type }}
+    type: {{ .connectorType }}
     status: running
     connectors:
       - id: example

--- a/conn-sdk-cli/readmegen/templates/parameters.yaml.tmpl
+++ b/conn-sdk-cli/readmegen/templates/parameters.yaml.tmpl
@@ -3,6 +3,7 @@
 version: 2.2
 pipelines:
   - id: example
+    type: {{ .type }}
     status: running
     connectors:
       - id: example

--- a/conn-sdk-cli/readmegen/testdata/test1want.md
+++ b/conn-sdk-cli/readmegen/testdata/test1want.md
@@ -16,6 +16,7 @@ Author: <!-- readmegen:author -->test author<!-- /readmegen:author -->
 version: 2.2
 pipelines:
   - id: example
+    type: source
     status: running
     connectors:
       - id: example
@@ -105,6 +106,7 @@ int param2 description
 version: 2.2
 pipelines:
   - id: example
+    type: destination
     status: running
     connectors:
       - id: example


### PR DESCRIPTION
### Description

Add the connector type to the generated yaml parameters.

Fixes #301 

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
