### PR TITLE
 Fix batcher not flushing when total size is over the batch size 

### DIFF
--- a/internal/batcher.go
+++ b/internal/batcher.go
@@ -66,7 +66,7 @@ func (b *Batcher[T]) Enqueue(item T, size int) EnqueueStatus {
 	b.batch = append(b.batch, item)
 	b.batchSize += size
 
-	if b.batchSize == b.sizeThreshold {
+	if b.batchSize >= b.sizeThreshold {
 		// trigger flush synchronously
 		_ = b.flushNow()
 		return Flushed


### PR DESCRIPTION
### Description

Lovro and I were going over some code in the SDK, and realized this issue.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-sdk/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
