### PR TITLE
fix: where type is added

### DIFF
--- a/conn-sdk-cli/readmegen/preprocess.go
+++ b/conn-sdk-cli/readmegen/preprocess.go
@@ -40,9 +40,9 @@ var (
 		"version":     `{{ .specification.version }}`,
 		"author":      `{{ .specification.author }}`,
 
-		"source.parameters.yaml":       `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.source.parameters }}`,
+		"source.parameters.yaml":       `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.source.parameters "connectorType" "source" }}`,
 		"source.parameters.table":      `{{ template "parameters.table" args "specification" .specification "parameters" .specification.source.parameters }}`,
-		"destination.parameters.yaml":  `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.destination.parameters }}`,
+		"destination.parameters.yaml":  `{{ template "parameters.yaml" args "specification" .specification "parameters" .specification.destination.parameters "connectorType" "destination" }}`,
 		"destination.parameters.table": `{{ template "parameters.table" args "specification" .specification "parameters" .specification.destination.parameters }}`,
 	}
 	errReadmegenCommentNotFound = errors.New("readmegen open tag not found")

--- a/conn-sdk-cli/readmegen/templates/parameters.yaml.tmpl
+++ b/conn-sdk-cli/readmegen/templates/parameters.yaml.tmpl
@@ -7,6 +7,7 @@ pipelines:
     connectors:
       - id: example
         plugin: "{{ .specification.name }}"
+        type: {{ .connectorType }}
         settings:
         {{- range $param := .parameters }}
           {{ formatCommentYAML $param.description 10 }}

--- a/conn-sdk-cli/readmegen/testdata/test1want.md
+++ b/conn-sdk-cli/readmegen/testdata/test1want.md
@@ -20,6 +20,7 @@ pipelines:
     connectors:
       - id: example
         plugin: "test-connector"
+        type: source
         settings:
           # string param1 description
           # Type: string
@@ -109,6 +110,7 @@ pipelines:
     connectors:
       - id: example
         plugin: "test-connector"
+        type: destination
         settings:
           # boolean param1 description
           # Type: boolean


### PR DESCRIPTION
Reverts ConduitIO/conduit-connector-sdk#307 and fix

Type was added incorrectly to the pipeline, not the connector.