### PR TITLE
perf: add record serialization + middleware benchmarks

### DIFF
--- a/middleware_bench_test.go
+++ b/middleware_bench_test.go
@@ -1,0 +1,203 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdk
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/conduitio/conduit-commons/lang"
+	"github.com/conduitio/conduit-commons/opencdc"
+	"github.com/conduitio/conduit-commons/schema/avro"
+	"github.com/conduitio/conduit-connector-sdk/schema"
+)
+
+// nopBenchDestination is a minimal Destination implementation used to isolate
+// middleware overhead from any actual I/O in benchmarks.
+type nopBenchDestination struct {
+	UnimplementedDestination
+}
+
+func (nopBenchDestination) Write(_ context.Context, recs []opencdc.Record) (int, error) {
+	return len(recs), nil
+}
+
+// benchmarkSchemaTestData is the structured payload encoded/decoded by the
+// schema middleware benchmarks below.
+func benchmarkSchemaTestData() opencdc.StructuredData {
+	return opencdc.StructuredData{
+		"id":         "a1b2c3d4",
+		"name":       "Jane Doe",
+		"email":      "jane@example.com",
+		"active":     true,
+		"created_at": time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		"balance":    1234.56,
+	}
+}
+
+// BenchmarkDestinationWithSchemaExtraction_Write benchmarks the destination
+// middleware that decodes a record's key and payload using a schema fetched
+// from the schema service, run on every record on the destination write path
+// when sdk.schema.extract.*.enabled is true (the default).
+func BenchmarkDestinationWithSchemaExtraction_Write(b *testing.B) {
+	ctx := context.Background()
+
+	testData := benchmarkSchemaTestData()
+	srd, err := avro.SerdeForType(testData)
+	if err != nil {
+		b.Fatal(err)
+	}
+	sch, err := schema.Create(ctx, schema.TypeAvro, "BenchmarkDestinationWithSchemaExtraction_Write", []byte(srd.String()))
+	if err != nil {
+		b.Fatal(err)
+	}
+	encoded, err := sch.Marshal(testData)
+	if err != nil {
+		b.Fatal(err)
+	}
+	rawData := opencdc.RawData(encoded)
+
+	schemaMetadata := opencdc.Metadata{
+		opencdc.MetadataKeySchemaSubject:     sch.Subject,
+		opencdc.MetadataKeySchemaVersion:     strconv.Itoa(sch.Version),
+		opencdc.MetadataPayloadSchemaSubject: sch.Subject,
+		opencdc.MetadataPayloadSchemaVersion: strconv.Itoa(sch.Version),
+	}
+
+	dw := (&DestinationWithSchemaExtraction{
+		PayloadEnabled: lang.Ptr(true),
+		KeyEnabled:     lang.Ptr(true),
+	}).Wrap(nopBenchDestination{})
+
+	b.Run("raw_avro_decode", func(b *testing.B) {
+		// Records carry raw, avro-encoded key/payload plus the schema
+		// subject/version in metadata: the realistic case where the source
+		// side attached a schema and the destination must decode it.
+		recs := make([]opencdc.Record, b.N)
+		for i := range recs {
+			recs[i] = opencdc.Record{
+				Metadata: schemaMetadata,
+				Key:      rawData,
+				Payload:  opencdc.Change{After: rawData},
+			}
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := range recs {
+			if _, err := dw.Write(ctx, recs[i:i+1]); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("structured_passthrough", func(b *testing.B) {
+		// Records already carry structured data (e.g. produced in-process by
+		// a source middleware chain): decode() returns immediately without
+		// touching the schema service, so this measures pure middleware
+		// overhead.
+		recs := make([]opencdc.Record, b.N)
+		for i := range recs {
+			recs[i] = opencdc.Record{
+				Metadata: schemaMetadata,
+				Key:      testData,
+				Payload:  opencdc.Change{After: testData},
+			}
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := range recs {
+			if _, err := dw.Write(ctx, recs[i:i+1]); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkSourceWithEncoding_Encode benchmarks the source middleware that
+// encodes a record's structured key/payload using the schema referenced in
+// its metadata, run on every record on the source read path once a schema
+// has been extracted (see SourceWithSchemaExtraction).
+func BenchmarkSourceWithEncoding_Encode(b *testing.B) {
+	ctx := context.Background()
+
+	testData := benchmarkSchemaTestData()
+	srd, err := avro.SerdeForType(testData)
+	if err != nil {
+		b.Fatal(err)
+	}
+	sch, err := schema.Create(ctx, schema.TypeAvro, "BenchmarkSourceWithEncoding_Encode", []byte(srd.String()))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	schemaMetadata := opencdc.Metadata{
+		opencdc.MetadataKeySchemaSubject:     sch.Subject,
+		opencdc.MetadataKeySchemaVersion:     strconv.Itoa(sch.Version),
+		opencdc.MetadataPayloadSchemaSubject: sch.Subject,
+		opencdc.MetadataPayloadSchemaVersion: strconv.Itoa(sch.Version),
+	}
+
+	// Wrap(nil) is safe here: sourceWithEncoding.encode never touches the
+	// wrapped Source, only Read/ReadN do, and those aren't exercised below.
+	sw, ok := (SourceWithEncoding{}).Wrap(nil).(*sourceWithEncoding)
+	if !ok {
+		b.Fatal("Wrap did not return a *sourceWithEncoding")
+	}
+
+	b.Run("structured_avro_encode", func(b *testing.B) {
+		recs := make([]opencdc.Record, b.N)
+		for i := range recs {
+			recs[i] = opencdc.Record{
+				Metadata: schemaMetadata,
+				Key:      testData,
+				Payload:  opencdc.Change{Before: testData, After: testData},
+			}
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := range recs {
+			if err := sw.encode(ctx, &recs[i]); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("raw_passthrough", func(b *testing.B) {
+		// Records with unstructured data are left untouched (only a one-time
+		// warning is logged), measuring pure middleware overhead.
+		rawData := opencdc.RawData(`{"id":"a1b2c3d4"}`)
+		recs := make([]opencdc.Record, b.N)
+		for i := range recs {
+			recs[i] = opencdc.Record{
+				Metadata: schemaMetadata,
+				Key:      rawData,
+				Payload:  opencdc.Change{Before: rawData, After: rawData},
+			}
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := range recs {
+			if err := sw.encode(ctx, &recs[i]); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/record_serializer_test.go
+++ b/record_serializer_test.go
@@ -48,6 +48,118 @@ func BenchmarkJSONEncoder(b *testing.B) {
 	}
 }
 
+// benchmarkRawRecord returns a record with raw key and payload, resembling a
+// record produced by a connector that doesn't attach structured data (e.g. a
+// file or generic byte-stream source). The payload is valid JSON so that
+// converters attempting to parse raw data as JSON (e.g. DebeziumConverter)
+// exercise their real parsing path instead of falling back to an error.
+func benchmarkRawRecord() opencdc.Record {
+	return opencdc.Record{
+		Position:  opencdc.Position("benchmark-position-00000001"),
+		Operation: opencdc.OperationCreate,
+		Metadata: opencdc.Metadata{
+			opencdc.MetadataConduitSourcePluginName: "benchmark-source",
+			opencdc.MetadataCollection:              "users",
+		},
+		Key: opencdc.RawData(`{"id":"a1b2c3d4"}`),
+		Payload: opencdc.Change{
+			Before: nil,
+			After:  opencdc.RawData(`{"id":"a1b2c3d4","name":"Jane Doe","email":"jane@example.com","active":true,"created_at":"2026-01-01T00:00:00Z","balance":1234.56}`),
+		},
+	}
+}
+
+// benchmarkStructuredRecord returns a record with structured key and payload,
+// resembling a record produced by a connector with native structured data
+// support (e.g. a database CDC source).
+func benchmarkStructuredRecord() opencdc.Record {
+	return opencdc.Record{
+		Position:  opencdc.Position("benchmark-position-00000001"),
+		Operation: opencdc.OperationUpdate,
+		Metadata: opencdc.Metadata{
+			opencdc.MetadataConduitSourcePluginName: "benchmark-source",
+			opencdc.MetadataCollection:              "users",
+		},
+		Key: opencdc.StructuredData{"id": "a1b2c3d4"},
+		Payload: opencdc.Change{
+			Before: opencdc.StructuredData{
+				"id":         "a1b2c3d4",
+				"name":       "Jane Doe",
+				"email":      "jane@old-example.com",
+				"active":     true,
+				"created_at": "2026-01-01T00:00:00Z",
+				"balance":    1200.00,
+			},
+			After: opencdc.StructuredData{
+				"id":         "a1b2c3d4",
+				"name":       "Jane Doe",
+				"email":      "jane@example.com",
+				"active":     true,
+				"created_at": "2026-01-01T00:00:00Z",
+				"balance":    1234.56,
+			},
+		},
+	}
+}
+
+// BenchmarkGenericRecordSerializer benchmarks the full destination
+// serialization hot path (Converter.Convert + Encoder.Encode combined through
+// GenericRecordSerializer.Serialize), for every combination of converter and
+// record shape shipped as a default record serializer.
+func BenchmarkGenericRecordSerializer(b *testing.B) {
+	records := map[string]opencdc.Record{
+		"raw":        benchmarkRawRecord(),
+		"structured": benchmarkStructuredRecord(),
+	}
+	serializers := map[string]RecordSerializer{
+		"opencdc/json":  GenericRecordSerializer{Converter: OpenCDCConverter{}, Encoder: JSONEncoder{}},
+		"debezium/json": GenericRecordSerializer{Converter: DebeziumConverter{}, Encoder: JSONEncoder{}},
+	}
+
+	for serName, ser := range serializers {
+		for recName, rec := range records {
+			b.Run(serName+"/"+recName, func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					encBytesSink, encErrSink = ser.Serialize(rec)
+				}
+				if encErrSink != nil {
+					b.Fatal(encErrSink)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkTemplateRecordSerializer benchmarks TemplateRecordSerializer,
+// which destinations can select via sdk.record.format=template to fully
+// customize the output. The "toJson" template mirrors the opencdc/json output
+// and is the most common non-trivial template in use.
+func BenchmarkTemplateRecordSerializer(b *testing.B) {
+	var serializer RecordSerializer = TemplateRecordSerializer{}
+	serializer, err := serializer.Configure(`{{ toJson . }}`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	records := map[string]opencdc.Record{
+		"raw":        benchmarkRawRecord(),
+		"structured": benchmarkStructuredRecord(),
+	}
+
+	for recName, rec := range records {
+		b.Run(recName, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				encBytesSink, encErrSink = serializer.Serialize(rec)
+			}
+			if encErrSink != nil {
+				b.Fatal(encErrSink)
+			}
+		})
+	}
+}
+
 func TestOpenCDCConverter(t *testing.T) {
 	is := is.New(t)
 	var converter OpenCDCConverter


### PR DESCRIPTION
## Summary

Rounds out benchmark coverage for hot paths in the record-serialization and
schema-middleware code that had no benchmarks yet.

Existing coverage before this PR (unchanged):
- `BenchmarkJSONEncoder` (`record_serializer_test.go`) — `JSONEncoder.Encode` in isolation
- `BenchmarkBatcher_Enqueue` (`internal/batcher_test.go`)
- `BenchmarkSource` (`benchmark.go`) — a public helper connector authors use to benchmark *their own* Source, not a benchmark of the SDK itself

Newly added:
- `BenchmarkGenericRecordSerializer` (`record_serializer_test.go`) — the full
  destination `Converter.Convert` + `Encoder.Encode` path via
  `GenericRecordSerializer.Serialize`, for `opencdc/json` and `debezium/json`,
  each against a raw and a structured record.
- `BenchmarkTemplateRecordSerializer` (`record_serializer_test.go`) —
  `TemplateRecordSerializer.Serialize` with a `toJson` template, raw and
  structured records.
- `BenchmarkDestinationWithSchemaExtraction_Write` (`middleware_bench_test.go`) —
  the destination middleware that decodes key/payload with a schema fetched
  from the schema service; `raw_avro_decode` (real avro decode) vs.
  `structured_passthrough` (already-decoded fast path).
- `BenchmarkSourceWithEncoding_Encode` (`middleware_bench_test.go`) — the
  source middleware that encodes structured key/payload with a schema;
  `structured_avro_encode` vs. `raw_passthrough` (nothing to encode).

Skipped: `DestinationWithRecordFormat.Write` only calls `SetSerializer` and
forwards — the actual serialization cost is already captured by the
`RecordSerializer` benchmarks above, so a separate benchmark there would just
measure a no-op wrapper.

## Numbers (Apple M3 Max, `-benchtime 2s`)

```
BenchmarkDestinationWithSchemaExtraction_Write/raw_avro_decode-16          776372     2633 ns/op    1424 B/op   36 allocs/op
BenchmarkDestinationWithSchemaExtraction_Write/structured_passthrough-16 51502881    49.46 ns/op       0 B/op    0 allocs/op
BenchmarkSourceWithEncoding_Encode/structured_avro_encode-16               581666     3808 ns/op     760 B/op   13 allocs/op
BenchmarkSourceWithEncoding_Encode/raw_passthrough-16                  202056045    43.51 ns/op       0 B/op    0 allocs/op
BenchmarkGenericRecordSerializer/opencdc/json/raw-16                     2020802     1115 ns/op     858 B/op    6 allocs/op
BenchmarkGenericRecordSerializer/opencdc/json/structured-16              1000000     2089 ns/op    1275 B/op    8 allocs/op
BenchmarkGenericRecordSerializer/debezium/json/raw-16                     228223    12347 ns/op   13369 B/op   90 allocs/op
BenchmarkGenericRecordSerializer/debezium/json/structured-16              235048    10688 ns/op   12828 B/op   70 allocs/op
BenchmarkTemplateRecordSerializer/structured-16                           686336     3561 ns/op    2887 B/op   45 allocs/op
BenchmarkTemplateRecordSerializer/raw-16                                 1522999     1584 ns/op    1748 B/op   16 allocs/op
```

Debezium conversion is ~10x costlier than the plain OpenCDC passthrough
(schema-envelope construction), and schema-middleware cost is dominated
entirely by whether a decode/encode actually happens — the passthrough case
is free.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go test -race ./... -count=1`
- [x] `go test -bench . -benchmem -benchtime 2s ./...`
- [x] `golangci-lint run ./...` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tapg9dLWXKMZJoL65R24vd