### PR TITLE
docs: godoc and package-doc pass

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -72,14 +72,32 @@ You need to implement the functions required by [Source] and provide your
 own implementations. Please look at the documentation of [Source] for
 further information about individual functions.
 
+Your source's configuration struct should embed [DefaultSourceMiddleware],
+which contributes the SDK's default source middleware (schema extraction,
+schema context, encoding and batching) as configuration fields. Return a
+pointer to that struct from Source.Config so the SDK can populate it from the
+pipeline configuration:
+
+	type SourceConfig struct {
+	  sdk.DefaultSourceMiddleware
+	  // your own configuration fields go here
+	}
+
+	func (s *Source) Config() sdk.SourceConfig {
+	  return &s.config
+	}
+
 You should also create a constructor function for your source struct.
 Note that this is the same function that should be set as the value of
-[Connector].NewSource. The constructor should be used to wrap your source in
-the default middleware. You can add additional middleware, but unless you
-have a very good reason, you should always include the default middleware.
+[Connector].NewSource. The constructor should wrap the source in the
+middleware declared in its configuration using [SourceWithMiddleware], which
+inspects the struct returned by Config and applies every embedded middleware.
+Unless you have a very good reason, you should always keep the embedded
+[DefaultSourceMiddleware]; add further middleware by embedding additional
+middleware config structs alongside it.
 
 	func NewSource() sdk.Source {
-	  return sdk.SourceWithMiddleware(&Source{}, sdk.DefaultSourceMiddleware()...)
+	  return sdk.SourceWithMiddleware(&Source{})
 	}
 
 Additional tips for implementing a source:
@@ -105,22 +123,40 @@ potentially change the interface in the future while remaining backwards
 compatible with existing [Destination] implementations.
 
 	type Destination struct {
-	  sdk.UnimplementedSource
+	  sdk.UnimplementedDestination
 	}
 
 You need to implement the functions required by [Destination] and provide
 your own implementations. Please look at the documentation of [Destination]
 for further information about individual functions.
 
+Your destination's configuration struct should embed
+[DefaultDestinationMiddleware], which contributes the SDK's default
+destination middleware (rate limiting, record format, batching and schema
+extraction) as configuration fields. Return a pointer to that struct from
+Destination.Config so the SDK can populate it from the pipeline
+configuration:
+
+	type DestinationConfig struct {
+	  sdk.DefaultDestinationMiddleware
+	  // your own configuration fields go here
+	}
+
+	func (d *Destination) Config() sdk.DestinationConfig {
+	  return &d.config
+	}
+
 You should also create a constructor function for your destination struct.
 Note that this is the same function that should be set as the value of
-[Connector].NewDestination. The constructor should be used to wrap your
-destination in the default middleware. You can add additional middleware,
-but unless you have a very good reason, you should always include the
-default middleware.
+[Connector].NewDestination. The constructor should wrap the destination in
+the middleware declared in its configuration using [DestinationWithMiddleware],
+which inspects the struct returned by Config and applies every embedded
+middleware. Unless you have a very good reason, you should always keep the
+embedded [DefaultDestinationMiddleware]; add further middleware by embedding
+additional middleware config structs alongside it.
 
 	func NewDestination() sdk.Destination {
-	  return sdk.DestinationWithMiddleware(&Destination{}, sdk.DefaultDestinationMiddleware()...)
+	  return sdk.DestinationWithMiddleware(&Destination{})
 	}
 
 Additional tips for implementing a destination:

--- a/internal/doc.go
+++ b/internal/doc.go
@@ -1,0 +1,46 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package internal holds implementation details shared by the SDK that are not
+// part of the connector-author-facing API. Nothing here is importable by
+// connectors; the parent sdk package re-exports the few pieces authors need
+// (for example ConnectorIDFromContext).
+//
+// It contains four largely independent concerns:
+//
+//   - Connector state machine ([ConnectorState], [ConnectorStateWatcher]). The
+//     plugin adapters drive a connector through an ordered set of lifecycle
+//     states (initial → configuring → configured → starting → ... → torn down,
+//     plus a terminal errored state). DoWithLock serializes state transitions:
+//     it takes the state lock, checks the current state against the expected
+//     states (optionally waiting for one of them), runs the supplied function,
+//     and applies the before/after states. This is what enforces that, for
+//     example, Run only proceeds from the started state.
+//
+//   - Batching ([Batcher]). A generic size-and-delay batcher: items are
+//     enqueued and flushed either when the accumulated size crosses a threshold
+//     or after a delay elapses, whichever comes first. The destination batch
+//     write strategy uses it to group records before writing.
+//
+//   - Context enrichment (Enrich and the ContextWith*/*FromContext helpers).
+//     Every adapter call enriches the context with connector metadata (ID and
+//     log level) so it is available to logging and to connector-utility calls
+//     further down the stack.
+//
+//   - Standalone utilities ([StandaloneConnectorUtility],
+//     InitStandaloneConnectorUtilities). A registry of utilities (such as the
+//     schema service) that need a gRPC connection to Conduit when the connector
+//     runs as a standalone plugin. Each utility registers itself in an init
+//     function and is wired up once, during standalone startup.
+package internal

--- a/record_serializer.go
+++ b/record_serializer.go
@@ -29,7 +29,12 @@ import (
 // RecordSerializer is a type that can format a record to bytes. It's used in
 // destination connectors to change the output structure and format.
 type RecordSerializer interface {
+	// Name returns the identifier of the serializer as it appears in the record
+	// format configuration (e.g. "opencdc/json").
 	Name() string
+	// Configure parses the raw options string and returns a new, configured
+	// RecordSerializer. It does not mutate the receiver, so the zero value can be
+	// used as a template from which configured instances are derived.
 	Configure(string) (RecordSerializer, error)
 	opencdc.RecordSerializer
 }
@@ -60,8 +65,14 @@ type GenericRecordSerializer struct {
 // destination connectors to change the output structure (e.g. opencdc records,
 // debezium records etc.).
 type Converter interface {
+	// Name returns the identifier of the converter, used as the first half of a
+	// record format name (e.g. "opencdc" or "debezium").
 	Name() string
+	// Configure returns a new Converter configured with the given options; it
+	// does not mutate the receiver.
 	Configure(map[string]string) (Converter, error)
+	// Convert transforms the record into the target structure. It does not
+	// encode it to bytes; that is the Encoder's job.
 	Convert(opencdc.Record) (any, error)
 }
 
@@ -69,8 +80,14 @@ type Converter interface {
 // used in destination connectors to encode records into different formats
 // (e.g. JSON, Avro etc.).
 type Encoder interface {
+	// Name returns the identifier of the encoder, used as the second half of a
+	// record format name (e.g. "json").
 	Name() string
+	// Configure returns a new Encoder configured with the given options; it does
+	// not mutate the receiver.
 	Configure(options map[string]string) (Encoder, error)
+	// Encode marshals the value produced by a Converter into its byte
+	// representation.
 	Encode(r any) ([]byte, error)
 }
 

--- a/schema/commons.go
+++ b/schema/commons.go
@@ -34,15 +34,27 @@ type (
 )
 
 const (
+	// TypeAvro is the only schema type currently supported by the schema service.
 	TypeAvro = schema.TypeAvro
 )
 
+// KnownSerdeFactories maps each supported schema [Type] to a factory that builds
+// the corresponding serializer/deserializer. It is used to encode and decode
+// record data against a registered schema.
 var KnownSerdeFactories = schema.KnownSerdeFactories
 
+// AttachKeySchemaToRecord records the subject and version of s in r's metadata,
+// marking s as the schema of the record key. It mutates r.Metadata in place
+// (the map is shared even though r is passed by value), so r.Metadata must be
+// non-nil.
 func AttachKeySchemaToRecord(r opencdc.Record, s Schema) {
 	schema.AttachKeySchemaToRecord(r, s)
 }
 
+// AttachPayloadSchemaToRecord records the subject and version of s in r's
+// metadata, marking s as the schema of the record payload. It mutates
+// r.Metadata in place (the map is shared even though r is passed by value), so
+// r.Metadata must be non-nil.
 func AttachPayloadSchemaToRecord(r opencdc.Record, s Schema) {
 	schema.AttachPayloadSchemaToRecord(r, s)
 }

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package schema gives connectors access to Conduit's schema registry. A
+// connector uses it to register the schema of the records it produces (a
+// source) or to fetch the schema of the records it receives (a destination),
+// so that record payloads and keys can be encoded and decoded consistently
+// across a pipeline.
+//
+// The main entry points are [Create], which registers a schema under a subject
+// and returns it with an assigned ID and version, and [Get], which retrieves a
+// previously registered schema by subject and version. Both delegate to
+// [Service], the package-level schema service client.
+//
+// # Service resolution
+//
+// [Service] defaults to an in-memory implementation, which is what runs when a
+// connector is exercised in tests or built into Conduit. When a connector runs
+// as a standalone plugin, the SDK calls Init during startup (registered through
+// the internal standalone-utilities mechanism) and swaps Service for a
+// gRPC-backed client that talks to Conduit's schema registry. In both cases the
+// service is wrapped in a cache that memoizes Create and Get responses for 15
+// minutes, so repeatedly registering or fetching the same schema on the hot
+// path is cheap.
+//
+// # Schema contexts
+//
+// A schema context namespaces subjects so that connectors running in different
+// contexts do not collide on subject names. Use [WithSchemaContextName] to put
+// a context name on the [context.Context]; [Create] then prefixes the subject
+// with it (as "<context>:<subject>"). [GetSchemaContextName] reads it back.
+//
+// # Invariants
+//
+//   - Only Avro is currently supported. Creating a schema with any other type
+//     returns an error.
+//   - Versions are assigned by the registry, start at 1, and increase by one
+//     with each new schema registered under the same subject.
+//
+// This package re-exports the core schema types (see [Type], [Schema], [Serde])
+// from github.com/conduitio/conduit-commons/schema so connectors do not have to
+// import that package directly. The source and destination schema-extraction
+// middleware in the parent sdk package build on these helpers, in particular
+// [AttachKeySchemaToRecord] and [AttachPayloadSchemaToRecord].
+package schema

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -30,10 +30,18 @@ func init() {
 }
 
 var (
+	// ErrSubjectNotFound is returned by [Get] when no schema has been registered
+	// under the requested subject.
 	ErrSubjectNotFound = pconnutils.ErrSubjectNotFound
+	// ErrVersionNotFound is returned by [Get] when the subject exists but the
+	// requested version has not been registered.
 	ErrVersionNotFound = pconnutils.ErrVersionNotFound
-	ErrInvalidSchema   = pconnutils.ErrInvalidSchema
+	// ErrInvalidSchema is returned when the provided schema bytes are not a valid
+	// schema of the given type.
+	ErrInvalidSchema = pconnutils.ErrInvalidSchema
 
+	// ErrUnsupportedType is returned when a schema type other than Avro is used;
+	// Avro is currently the only supported type.
 	ErrUnsupportedType = schema.ErrUnsupportedType
 )
 

--- a/source_middleware.go
+++ b/source_middleware.go
@@ -43,6 +43,11 @@ var (
 	_ SourceMiddleware = (*SourceWithSchemaExtraction)(nil)
 )
 
+// DefaultSourceMiddleware should be embedded in the SourceConfig struct to
+// provide the SDK's default source middleware as configuration fields. Its
+// fields are picked up by [SourceWithMiddleware], which wraps the source in the
+// corresponding middleware. Note that if the embedding struct overwrites
+// Validate manually, it should call Validate on this struct as well.
 type DefaultSourceMiddleware struct {
 	UnimplementedSourceConfig
 

--- a/util.go
+++ b/util.go
@@ -114,6 +114,11 @@ func YAMLSpecification(rawYaml, version string) func() Specification {
 	return func() Specification { return specs }
 }
 
+// ParseYAMLSpecification parses a Specification from the given YAML file,
+// optionally overriding the connector version with the version parameter (pass
+// an empty string to keep the version from the YAML). It is the error-returning
+// counterpart to [YAMLSpecification], which panics on failure; prefer this one
+// when the YAML is not known to be valid at build time.
 func ParseYAMLSpecification(ctx context.Context, rawYaml, version string) (Specification, error) {
 	logger := Logger(ctx)
 


### PR DESCRIPTION
## Summary

Docs-only pass on the connector SDK. No behavior, signatures, or logic changed.

**New package docs (`doc.go`):**
- `schema/doc.go` — purpose (schema registry access for connectors), the `Create`/`Get` entry points, service resolution (in-memory default vs. gRPC-backed standalone client, 15-min caching), schema contexts, and the Avro-only / version-starts-at-1 invariants.
- `internal/doc.go` — contributor-facing map of the four concerns living there: the connector state machine (`DoWithLock` transition guarding), the size/delay `Batcher`, context enrichment, and the standalone-utilities registry.

**Root `doc.go` getting-started guide refreshed:**
- The Source/Destination examples used a removed variadic API (`SourceWithMiddleware(&Source{}, sdk.DefaultSourceMiddleware()...)`). Updated to the current pattern: embed `sdk.DefaultSourceMiddleware` / `sdk.DefaultDestinationMiddleware` in your config struct, return it from `Config()`, and wrap with the single-arg `SourceWithMiddleware(&Source{})`.
- Fixed a copy-paste bug in the Destination example that embedded `sdk.UnimplementedSource` instead of `sdk.UnimplementedDestination`.

**Exported symbols documented (~15) where it adds information beyond the signature:**
- `DefaultSourceMiddleware` type — was undocumented; now mirrors its documented destination counterpart and explains the embed-in-config contract.
- `schema` errors (`ErrSubjectNotFound`, `ErrVersionNotFound`, `ErrInvalidSchema`, `ErrUnsupportedType`) — when each is returned.
- `schema.KnownSerdeFactories`, `TypeAvro`, and `AttachKeySchemaToRecord`/`AttachPayloadSchemaToRecord` — the latter two note the non-obvious in-place metadata mutation (map shared despite pass-by-value; metadata must be non-nil).
- `RecordSerializer`/`Converter`/`Encoder` interface methods — the non-obvious "Configure returns a new configured instance, does not mutate the receiver" contract.
- `ParseYAMLSpecification` — documented as the error-returning counterpart to the panicking `YAMLSpecification`.

## Highest-value contracts documented

- **Config-embedded middleware wiring** (the front-door getting-started guide) now matches the shipping API — previously it told authors to call a signature that no longer exists.
- **In-place metadata mutation** of the schema attach helpers.
- **Immutability of `Configure`** across the record-serializer extension points.

Note: the Source read/ack lifecycle, Destination write lifecycle, and position/ack semantics on `source.go`/`destination.go` were already thoroughly documented; I left them alone rather than pad. Trivial re-export methods (`Name()` returning a constant), unexported plugin adapters, and `testdata` fixtures were intentionally skipped — a comment there would only restate the name.

## Bugs noticed (not fixed)

None. (The `sdk.UnimplementedSource`-in-Destination-example was a doc typo, fixed here as part of the docs pass, not a code bug.)

## Verification

- `go build ./...` — clean
- `go test ./... -count=1` — all packages pass
- `golangci-lint run` (v2.12.2 via tools) — 0 issues

Docs-only change, no behavior change. Roadmap: Phase 0 developer-experience / SDK documentation quality.