### PR TITLE
docs: point doc links at conduitdata.io (conduit.io is dead)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Additionally, Conduit automatically adds the following metadata to each record:
 * `conduit.source.plugin.version`: version of the source plugin that created
   this record
 
-More information about metadata in OpenCDC records can be found [here](https://conduit.io/docs/features/opencdc-record/#opencdc).
+More information about metadata in OpenCDC records can be found [here](https://conduitdata.io/docs/features/opencdc-record).
 
 **Q: If a destination connector is able to write to multiple tables (topics,
 collections, indexes, etc.), how should a record be routed to the correct

--- a/conn-sdk-cli/specgen/README.md
+++ b/conn-sdk-cli/specgen/README.md
@@ -43,4 +43,4 @@ var Connector = sdk.Connector{
 
 More detailed information about `specgen` and `connector.yaml` can be found in
 the
-[Conduit documentation](https://conduit.io/docs/developing/connectors/connector-specification).
+[Conduit documentation](https://conduitdata.io/docs/developing/connectors/connector-specification).

--- a/destination_middleware.go
+++ b/destination_middleware.go
@@ -288,7 +288,7 @@ type DestinationWithRecordFormat struct {
 	UnimplementedDestinationConfig
 
 	// The format of the output record. See the Conduit documentation for a full
-	// list of supported formats (https://conduit.io/docs/using/connectors/configuration-parameters/output-format).
+	// list of supported formats (https://conduitdata.io/docs/using/connectors/configuration-parameters/output-format).
 	RecordFormat *string `json:"sdk.record.format" default:"opencdc/json"`
 	// Options to configure the chosen output record format. Options are normally
 	// key=value pairs separated with comma (e.g. opt1=val2,opt2=val2), except


### PR DESCRIPTION
## What

The last three `conduit.io` doc links in the SDK now 404 — `conduit.io` no longer resolves (`curl` → `000`); `conduitdata.io` is the docs domain. This repoints them, closing out the domain migration that landed in conduit core (#2664) and the docs site.

| File | Link |
| --- | --- |
| `destination_middleware.go` | `sdk.record.format` → output-format docs |
| `README.md` | OpenCDC record metadata link |
| `conn-sdk-cli/specgen/README.md` | connector-specification docs |

## Verification

All three target paths verified live (HTTP 200) on `conduitdata.io`; `conduit.io` returns `000` (dead). I dropped the stale `#opencdc` fragment from the README link — that anchor no longer exists on the current page, so linking to the page (which is entirely about the OpenCDC record) is correct; a swap that kept a dead fragment would not be.

`go build ./...`, `go vet ./...`, and `go generate ./...` all clean — no generated drift (the comment isn't embedded in any committed generated file).

## Risk tier

**Tier 3** (docs/comments only — no data-path, no public contract, no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)